### PR TITLE
mlock & mlock2 fail spuriously on some versions of Azul

### DIFF
--- a/src/main/java/net/openhft/posix/internal/core/Jvm.java
+++ b/src/main/java/net/openhft/posix/internal/core/Jvm.java
@@ -11,6 +11,7 @@ public final class Jvm {
     private Jvm() {
     }
     static final String OS_ARCH = System.getProperty("os.arch", "?");
+    static final String VM_VENDOR = System.getProperty("java.vm.vendor", "?");
 
     public static boolean isArm() {
         return Boolean.parseBoolean(System.getProperty("jvm.isarm")) ||
@@ -19,5 +20,9 @@ public final class Jvm {
 
     public static boolean is64bit() {
         return UnsafeMemory.IS64BIT;
+    }
+
+    public static boolean isAzul() { 
+        return VM_VENDOR.startsWith("Azul ");
     }
 }

--- a/src/main/java/net/openhft/posix/internal/jnr/JNRPosixAPI.java
+++ b/src/main/java/net/openhft/posix/internal/jnr/JNRPosixAPI.java
@@ -117,6 +117,7 @@ public final class JNRPosixAPI implements PosixAPI {
 
     @Override
     public boolean mlock(long addr, long length) {
+        if(Jvm.isAzul()) return true; // no-op on Azul, ignore
         int err = jnr.mlock(addr, length);
         if (err == 0)
             return true;
@@ -127,6 +128,7 @@ public final class JNRPosixAPI implements PosixAPI {
 
     @Override
     public boolean mlock2(long addr, long length, boolean lockOnFault) {
+        if(Jvm.isAzul()) return true; // no-op on Azul, ignore
         int err = mlock2_(addr, length, lockOnFault);
         if (err == 0)
             return true;

--- a/src/main/java/net/openhft/posix/internal/jnr/JNRPosixAPI.java
+++ b/src/main/java/net/openhft/posix/internal/jnr/JNRPosixAPI.java
@@ -9,6 +9,8 @@ import net.openhft.posix.*;
 import net.openhft.posix.internal.UnsafeMemory;
 import net.openhft.posix.internal.core.Jvm;
 import net.openhft.posix.internal.core.OS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.function.IntSupplier;
@@ -16,6 +18,8 @@ import java.util.function.IntSupplier;
 import static net.openhft.posix.internal.UnsafeMemory.UNSAFE;
 
 public final class JNRPosixAPI implements PosixAPI {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JNRPosixAPI.class);
 
     static final jnr.ffi.Runtime RUNTIME = FFIProvider.getSystemProvider().getRuntime();
     static final jnr.ffi.Platform NATIVE_PLATFORM = Platform.getNativePlatform();
@@ -117,7 +121,11 @@ public final class JNRPosixAPI implements PosixAPI {
 
     @Override
     public boolean mlock(long addr, long length) {
-        if(Jvm.isAzul()) return true; // no-op on Azul, ignore
+        if(Jvm.isAzul()) {
+            LOGGER.warn("mlock called but ignored for Azul");
+            return true; // no-op on Azul, ignore
+        }
+
         int err = jnr.mlock(addr, length);
         if (err == 0)
             return true;
@@ -128,7 +136,10 @@ public final class JNRPosixAPI implements PosixAPI {
 
     @Override
     public boolean mlock2(long addr, long length, boolean lockOnFault) {
-        if(Jvm.isAzul()) return true; // no-op on Azul, ignore
+        if(Jvm.isAzul()) {
+            LOGGER.warn("mlock2 called but ignored for Azul");
+            return true; // no-op on Azul, ignore
+        }
         int err = mlock2_(addr, length, lockOnFault);
         if (err == 0)
             return true;


### PR DESCRIPTION
The issue is caused by Azul causing ENOMEM on mlock and mlock2 calls, even though the parameters passed appear valid.
As this works in newer versions of Azul it seems to be an issue within Azul itself. There are some google hits on Azul/mlock but I didn't find anything definite on a quick scan. mlock/2 are very rarely used/needed so for now these have been changed to no-ops if running under Azul.