### PR TITLE
Improve Mapping class javadoc

### DIFF
--- a/src/main/java/net/openhft/posix/Mapping.java
+++ b/src/main/java/net/openhft/posix/Mapping.java
@@ -3,8 +3,14 @@ package net.openhft.posix;
 import net.openhft.posix.internal.UnsafeMemory;
 
 /**
- * This class represents a memory mapping in the /proc/[pid]/maps file.
- * It parses and stores the details of a single memory mapping.
+ * Immutable value object for one line of {@code /proc/$pid/maps}.
+ *
+ * Example line:
+ * {@code 00400000-0040b000 r-xp 00000000 08:02 367546 /bin/cat}
+ * <br>addr range | perms | offset | device | inode | path
+ *
+ * On a 32-bit VM the addresses are truncated.
+ * Instances are thread-safe and immutable.
  */
 public final class Mapping {
     // The start address of the memory mapping


### PR DESCRIPTION
## Summary
- document `Mapping` as an immutable value object representing `/proc/$pid/maps` entries
- note example line, truncated addresses on 32-bit VMs, and thread-safety

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*