### PR TITLE
Clarify PosixAPI initialisation

### DIFF
--- a/src/main/java/net/openhft/posix/PosixAPI.java
+++ b/src/main/java/net/openhft/posix/PosixAPI.java
@@ -16,7 +16,14 @@ import static net.openhft.posix.internal.UnsafeMemory.UNSAFE;
 public interface PosixAPI {
 
     /**
-     * @return The fastest available PosixAPI implementation.
+     * Returns the lazily initialised {@link PosixAPI} instance.
+     * The method is idempotent but not thread-safe until the first
+     * successful load. Providers are attempted in the order
+     * {@code JNRPosixAPI}, {@code WinJNRPosixAPI},
+     * {@code JNAPosixAPI}, {@code NoOpPosixAPI} as set out in
+     * POSIX-FN-002.
+     *
+     * @return the selected PosixAPI
      */
     static PosixAPI posix() {
         PosixAPIHolder.loadPosixApi();

--- a/src/main/java/net/openhft/posix/internal/PosixAPIHolder.java
+++ b/src/main/java/net/openhft/posix/internal/PosixAPIHolder.java
@@ -15,9 +15,11 @@ public class PosixAPIHolder {
     public static PosixAPI POSIX_API;
 
     /**
-     * Loads the appropriate PosixAPI implementation based on the native platform.
-     * If the platform is Unix, it loads {@link JNRPosixAPI}, otherwise it loads {@link WinJNRPosixAPI}.
-     * If an error occurs during loading, it falls back to {@link NoOpPosixAPI}.
+     * Loads the fastest compatible provider into {@link #POSIX_API}.
+     * Idempotent but not thread-safe until the first successful load.
+     * The provider fallback order is {@code JNRPosixAPI},
+     * {@code WinJNRPosixAPI}, {@code JNAPosixAPI},
+     * {@code NoOpPosixAPI} (see POSIX-FN-002).
      */
     public static void loadPosixApi() {
         if (POSIX_API != null)


### PR DESCRIPTION
## Summary
- expand docs for PosixAPI.posix and PosixAPIHolder.loadPosixApi
  - note idempotence and lack of thread safety before first load
  - mention provider fallback sequence from POSIX-FN-002

## Testing
- `mvn -q verify` *(fails: mvn not found)*