### PR TITLE
Clarify native loading docs

### DIFF
--- a/src/main/java/net/openhft/posix/internal/jna/JNAPosixAPI.java
+++ b/src/main/java/net/openhft/posix/internal/jna/JNAPosixAPI.java
@@ -7,8 +7,13 @@ import com.sun.jna.Pointer;
 import net.openhft.posix.PosixAPI;
 
 /**
- * Abstract class implementing {@link PosixAPI} using JNA (Java Native Access).
- * It provides methods for memory mapping operations, leveraging the JNA library.
+ * Abstract {@link PosixAPI} based on JNA (Java Native Access).
+ *
+ * <p>Instantiating this class loads the platform C library via
+ * {@code NativeLibrary.getInstance}.  The search honours the
+ * {@code jna.library.path} system property.  The library is registered with
+ * {@code Native.register} and therefore cannot be unloaded for the lifetime of
+ * the JVM.</p>
  */
 public abstract class JNAPosixAPI implements PosixAPI {
     private static final Pointer NULL = Pointer.createConstant(0);
@@ -17,7 +22,8 @@ public abstract class JNAPosixAPI implements PosixAPI {
     private final JNAPosixInterface jna = new JNAPosixInterface();
 
     /**
-     * Constructs a JNAPosixAPI instance and initializes the JNA interface.
+     * Constructs a JNAPosixAPI and registers the POSIX natives.  The
+     * registration is global; JNA does not support unloading once registered.
      */
     public JNAPosixAPI() {
         NativeLibrary clib = NativeLibrary.getInstance(Platform.C_LIBRARY_NAME);

--- a/src/main/java/net/openhft/posix/internal/jnr/JNRPosixAPI.java
+++ b/src/main/java/net/openhft/posix/internal/jnr/JNRPosixAPI.java
@@ -19,7 +19,10 @@ import static net.openhft.posix.internal.UnsafeMemory.UNSAFE;
 
 /**
  * Implementation of {@link PosixAPI} using JNR (Java Native Runtime).
- * Provides POSIX-like methods for file and memory operations, leveraging the JNR library.
+ *
+ * <p>Where a JNR binding is absent this class issues raw syscalls using
+ * hard-coded numbers chosen for common architectures.  If the kernel does not
+ * recognise a number the call gracefully falls back to the available wrapper.</p>
  */
 public final class JNRPosixAPI implements PosixAPI {
 
@@ -61,6 +64,8 @@ public final class JNRPosixAPI implements PosixAPI {
 
     /**
      * Determines the appropriate method for getting the thread ID (gettid).
+     * The JNR binding is tried first and, if missing, the raw syscall numbers
+     * 224 or 186 are used.
      *
      * @return A supplier for the gettid method.
      */
@@ -234,6 +239,10 @@ public final class JNRPosixAPI implements PosixAPI {
         return jnr.msync(address, length, flags);
     }
 
+    /**
+     * RAII helper wrapping {@code flock}.  {@link #close()} may be invoked more
+     * than once and will simply attempt to release the lock again.
+     */
     public class FileLocker implements AutoCloseable {
         private final int fd;
 


### PR DESCRIPTION
## Summary
- document how JNA loads and registers the C library
- detail syscall fallback and FileLocker semantics in JNR

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*