### PR TITLE
Document MAP_FAILED return for mmap

### DIFF
--- a/src/main/java/net/openhft/posix/PosixAPI.java
+++ b/src/main/java/net/openhft/posix/PosixAPI.java
@@ -121,7 +121,10 @@ public interface PosixAPI {
      * @param flags  The flags.
      * @param fd     The file descriptor.
      * @param offset The offset.
-     * @return The starting address of the mapped area.
+     * @return The starting address of the mapped area, or {@code -1} if the
+     *         mapping failed. A return value of {@code -1} represents
+     *         {@code MAP_FAILED} and callers must consult
+     *         {@link #lastError()} for the cause.
      */
     default long mmap(long addr, long length, MMapProt prot, MMapFlag flags, int fd, long offset) {
         return mmap(addr, length, prot.value(), flags.value(), fd, offset);
@@ -136,7 +139,10 @@ public interface PosixAPI {
      * @param flags  The flags.
      * @param fd     The file descriptor.
      * @param offset The offset.
-     * @return The starting address of the mapped area.
+     * @return The starting address of the mapped area, or {@code -1} if the
+     *         mapping failed. A return value of {@code -1} represents
+     *         {@code MAP_FAILED} and callers must consult
+     *         {@link #lastError()} for the cause.
      */
     long mmap(long addr, long length, int prot, int flags, int fd, long offset);
 


### PR DESCRIPTION
## Summary
- clarify mmap Javadoc

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*