### PR TITLE
Move enum comments into Javadoc

### DIFF
--- a/src/main/java/net/openhft/posix/ClockId.java
+++ b/src/main/java/net/openhft/posix/ClockId.java
@@ -1,41 +1,42 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different clock IDs used in clock operations.
- * It defines the various clocks that can be used for timing and synchronization purposes.
+ * Clock IDs for operations like {@code clock_gettime}.
+ *
+ * <p>The integer values are binary-compatible with the glibc headers.
  */
 public enum ClockId {
-    // The system-wide real-time clock
+    /** The system-wide real-time clock. */
     CLOCK_REALTIME(0),
 
-    // The monotonic clock, which cannot be set and represents monotonic time since some unspecified starting point
+    /** Monotonic clock that cannot be set. */
     CLOCK_MONOTONIC(1),
 
-    // The clock measuring the CPU time consumed by the process
+    /** CPU time consumed by the process. */
     CLOCK_PROCESS_CPUTIME_ID(2),
 
-    // The clock measuring the CPU time consumed by the thread
+    /** CPU time consumed by the thread. */
     CLOCK_THREAD_CPUTIME_ID(3),
 
-    // The raw monotonic clock, without NTP adjustments
+    /** Monotonic clock without NTP adjustments. */
     CLOCK_MONOTONIC_RAW(4),
 
-    // The system-wide real-time clock, but faster and less accurate
+    /** Real-time clock with coarse granularity. */
     CLOCK_REALTIME_COARSE(5),
 
-    // The coarse monotonic clock, but faster and less accurate
+    /** Monotonic clock with coarse granularity. */
     CLOCK_MONOTONIC_COARSE(6),
 
-    // The monotonic clock that includes time spent in suspend
+    /** Monotonic clock that includes suspend time. */
     CLOCK_BOOTTIME(7),
 
-    // The system-wide real-time clock used to set alarms
+    /** Real-time clock used to set alarms. */
     CLOCK_REALTIME_ALARM(8),
 
-    // The boot-time clock used to set alarms
+    /** Boot-time clock used to set alarms. */
     CLOCK_BOOTTIME_ALARM(9),
 
-    // The SGI cycle counter
+    /** SGI cycle counter. */
     CLOCK_SGI_CYCLE(10);
 
     // The integer value representing the clock ID

--- a/src/main/java/net/openhft/posix/LockfFlag.java
+++ b/src/main/java/net/openhft/posix/LockfFlag.java
@@ -1,8 +1,9 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different flags for file locking (lockf) operations.
- * It defines the operations to be performed on file locks, such as locking, unlocking, and testing locks.
+ * Flags for {@code lockf}.
+ *
+ * <p>The integer values are binary-compatible with the glibc headers.
  */
 public enum LockfFlag {
     /**

--- a/src/main/java/net/openhft/posix/MAdviseFlag.java
+++ b/src/main/java/net/openhft/posix/MAdviseFlag.java
@@ -1,59 +1,60 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different flags for memory advice (madvise) operations.
- * It defines the advice to be given to the kernel about the intended usage pattern of memory.
+ * Advice flags for {@code madvise}.
+ *
+ * <p>The integer values are binary-compatible with the glibc headers.
  */
 public enum MAdviseFlag {
-    // No further special treatment
+    /** No further special treatment. */
     MADV_NORMAL(0),
 
-    // Expect random page references
+    /** Expect random page references. */
     MADV_RANDOM(1),
 
-    // Expect sequential page references
+    /** Expect sequential page references. */
     MADV_SEQUENTIAL(2),
 
-    // Will need these pages
+    /** Will need these pages. */
     MADV_WILLNEED(3),
 
-    // Don't need these pages
+    /** No need for these pages. */
     MADV_DONTNEED(4),
 
-    // Free pages only if memory pressure
+    /** Free pages only if memory pressure. */
     MADV_FREE(8),
 
-    // Remove these pages and resources
+    /** Remove these pages and resources. */
     MADV_REMOVE(9),
 
-    // Do not inherit across fork
+    /** Do not inherit across fork. */
     MADV_DONTFORK(10),
 
-    // Do inherit across fork
+    /** Inherit across fork. */
     MADV_DOFORK(11),
 
-    // KSM may merge identical pages
+    /** KSM may merge identical pages. */
     MADV_MERGEABLE(12),
 
-    // KSM may not merge identical pages
+    /** KSM may not merge identical pages. */
     MADV_UNMERGEABLE(13),
 
-    // Worth backing with hugepages
+    /** Hint backing with huge pages. */
     MADV_HUGEPAGE(14),
 
-    // Not worth backing with hugepages
+    /** Hint not worth backing with huge pages. */
     MADV_NOHUGEPAGE(15),
 
-    // Explicitly exclude from the core dump, overrides the coredump filter bits
+    /** Exclude from core dump and override the coredump filter. */
     MADV_DONTDUMP(16),
 
-    // Clear the MADV_DONTDUMP flag
+    /** Clear the MADV_DONTDUMP flag. */
     MADV_DODUMP(17),
 
-    // Zero memory on fork, child only
+    /** Zero memory on fork in the child. */
     MADV_WIPEONFORK(18),
 
-    // Undo MADV_WIPEONFORK
+    /** Undo MADV_WIPEONFORK. */
     MADV_KEEPONFORK(19);
 
     // The integer value representing the madvise flag

--- a/src/main/java/net/openhft/posix/MMapFlag.java
+++ b/src/main/java/net/openhft/posix/MMapFlag.java
@@ -1,14 +1,15 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different flags for mmap operations.
- * It defines the flags for memory mapping operations, including shared and private mappings.
+ * Flags for {@code mmap}.
+ *
+ * <p>The integer values are binary-compatible with the glibc headers.
  */
 public enum MMapFlag {
-    // Memory mapping to be shared with other processes
+    /** Memory mapping to be shared with other processes. */
     SHARED(1),
 
-    // Memory mapping to be private to the process
+    /** Memory mapping to be private to the process. */
     PRIVATE(2);
 
     // The integer value representing the mmap flag

--- a/src/main/java/net/openhft/posix/MMapProt.java
+++ b/src/main/java/net/openhft/posix/MMapProt.java
@@ -1,26 +1,27 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different memory protection options for mmap.
- * It defines the protection levels for memory mapping operations, including read, write, execute, and none.
+ * Protection flags for {@code mmap}.
+ *
+ * <p>The integer values are binary-compatible with the glibc headers.
  */
 public enum MMapProt {
-    // Memory protection to allow read access
+    /** Allow read access. */
     PROT_READ(1),
 
-    // Memory protection to allow write access
+    /** Allow write access. */
     PROT_WRITE(2),
 
-    // Memory protection to allow both read and write access
+    /** Allow both read and write access. */
     PROT_READ_WRITE(3),
 
-    // Memory protection to allow execute access
+    /** Allow execute access. */
     PROT_EXEC(4),
 
-    // Memory protection to allow both execute and read access
+    /** Allow execute and read access. */
     PROT_EXEC_READ(5),
 
-    // Memory protection to allow no access
+    /** No access allowed. */
     PROT_NONE(8);
 
     // The integer value representing the memory protection level

--- a/src/main/java/net/openhft/posix/MSyncFlag.java
+++ b/src/main/java/net/openhft/posix/MSyncFlag.java
@@ -1,8 +1,9 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different flags for memory synchronization (msync) operations.
- * It defines the flags used to control the behavior of memory synchronization operations.
+ * Flags for {@code msync}.
+ *
+ * <p>The integer values are binary-compatible with the glibc headers.
  */
 public enum MSyncFlag {
     /**

--- a/src/main/java/net/openhft/posix/MclFlag.java
+++ b/src/main/java/net/openhft/posix/MclFlag.java
@@ -1,20 +1,21 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different flags for memory locking (mlockall) operations.
- * It defines the flags used to control how pages are locked in memory.
+ * Flags for {@code mlockall}.
+ *
+ * <p>The integer values are binary-compatible with the glibc headers.
  */
 public enum MclFlag {
-    // Lock all current pages in memory
+    /** Lock all current pages in memory. */
     MclCurrent(1),
 
-    // Lock all future pages in memory
+    /** Lock all future pages in memory. */
     MclFuture(2),
 
-    // Lock all current pages in memory on fault
+    /** Lock all current pages in memory on fault. */
     MclCurrentOnFault(1 + 4),
 
-    // Lock all future pages in memory on fault
+    /** Lock all future pages in memory on fault. */
     MclFutureOnFault(2 + 4);
 
     // The integer code representing the mlockall flag

--- a/src/main/java/net/openhft/posix/OpenFlag.java
+++ b/src/main/java/net/openhft/posix/OpenFlag.java
@@ -1,44 +1,45 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different flags for opening files (open).
- * It defines the flags used to control the behavior of file opening operations.
+ * Flags for {@code open}.
+ *
+ * <p>The integer values are binary-compatible with the glibc headers.
  */
 public enum OpenFlag {
-    // Open for reading only
+    /** Open for reading only. */
     O_RDONLY(0x0000),
 
-    // Open for writing only
+    /** Open for writing only. */
     O_WRONLY(0x0001),
 
-    // Open for reading and writing
+    /** Open for reading and writing. */
     O_RDWR(0x0002),
 
-    // No delay (non-blocking mode)
+    /** Non-blocking mode. */
     O_NONBLOCK(0x0004),
 
-    // Set append mode
+    /** Append mode. */
     O_APPEND(0x0008),
 
-    // Open with shared file lock
+    /** Open with shared file lock. */
     O_SHLOCK(0x0010),
 
-    // Open with exclusive file lock
+    /** Open with exclusive file lock. */
     O_EXLOCK(0x0020),
 
-    // Signal pgrp when data is ready (asynchronous mode)
+    /** Signal process group when data is ready. */
     O_ASYNC(0x0040),
 
-    // Synchronous writes
+    /** Synchronous writes. */
     O_FSYNC(0x0080),
 
-    // Create if non-existent
+    /** Create if non-existent. */
     O_CREAT(0x0200),
 
-    // Truncate to zero length
+    /** Truncate to zero length. */
     O_TRUNC(0x0400),
 
-    // Error if already exists
+    /** Error if already exists. */
     O_EXCL(0x0800);
 
     // The integer value representing the open flag


### PR DESCRIPTION
## Summary
- move explanatory comments for enum constants into Javadoc
- note glibc compatibility in each enum's header

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*