### PR TITLE
Add errno-aware PosixRuntimeException

### DIFF
--- a/src/main/java/net/openhft/posix/PosixRuntimeException.java
+++ b/src/main/java/net/openhft/posix/PosixRuntimeException.java
@@ -8,13 +8,15 @@ public class PosixRuntimeException extends RuntimeException {
     // Serialization version UID for ensuring compatibility during deserialization
     private static final long serialVersionUID = 0L;
 
+    private final int errno;
+
     /**
      * Constructs a new PosixRuntimeException with the specified detail message.
      *
      * @param message The detail message for the exception.
      */
     public PosixRuntimeException(String message) {
-        super(message);
+        this(message, 0);
     }
 
     /**
@@ -24,5 +26,27 @@ public class PosixRuntimeException extends RuntimeException {
      */
     public PosixRuntimeException(Throwable cause) {
         super(cause);
+        this.errno = 0;
+    }
+
+    /**
+     * Constructs a new PosixRuntimeException with the specified detail message
+     * and errno.
+     * <p>
+     * The errno mirrors the result of {@link PosixAPI#lastError()}.
+     *
+     * @param message The detail message for the exception.
+     * @param errno   The POSIX error number.
+     */
+    public PosixRuntimeException(String message, int errno) {
+        super(message);
+        this.errno = errno;
+    }
+
+    /**
+     * @return the errno associated with this exception
+     */
+    public int errno() {
+        return errno;
     }
 }

--- a/src/main/java/net/openhft/posix/internal/jnr/JNRPosixAPI.java
+++ b/src/main/java/net/openhft/posix/internal/jnr/JNRPosixAPI.java
@@ -113,9 +113,9 @@ public final class JNRPosixAPI implements PosixAPI {
         final int lastError = RUNTIME.getLastError();
         for (Errno errno : Errno.values()) {
             if (errno.intValue() == lastError)
-                throw new PosixRuntimeException(msg + "error " + errno);
+                throw new PosixRuntimeException(msg + "error " + errno, lastError);
         }
-        throw new PosixRuntimeException(msg + "unknown error " + lastError);
+        throw new PosixRuntimeException(msg + "unknown error " + lastError, lastError);
     }
 
     @Override
@@ -127,7 +127,7 @@ public final class JNRPosixAPI implements PosixAPI {
             final int lastError = RUNTIME.getLastError();
             for (Errno errno : Errno.values()) {
                 if (errno.intValue() == lastError)
-                    throw new PosixRuntimeException(errno.toString());
+                    throw new PosixRuntimeException(errno.toString(), lastError);
             }
         }
         return mmap;


### PR DESCRIPTION
## Summary
- add an errno field in `PosixRuntimeException`
- provide a constructor that accepts `(String,int)` and document it
- update `JNRPosixAPI` to include the errno when creating exceptions

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*