### PR TITLE
Document unimplemented Win APIs

### DIFF
--- a/src/main/java/net/openhft/posix/internal/jnr/Kernel32JNRInterface.java
+++ b/src/main/java/net/openhft/posix/internal/jnr/Kernel32JNRInterface.java
@@ -1,21 +1,23 @@
 package net.openhft.posix.internal.jnr;
 
 /**
- * This interface defines the native methods for interacting with the Kernel32 library on Windows using JNR (Java Native Runtime).
+ * Native bindings to functions from Kernel32.dll.
  */
 public interface Kernel32JNRInterface {
 
     /**
-     * Retrieves the thread identifier of the calling thread.
+     * Retrieves the identifier of the calling thread.
      *
-     * @return The thread identifier of the calling thread.
+     * @return The thread identifier.
+     * @see <a href="https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentthreadid">GetCurrentThreadId</a>
      */
     int GetCurrentThreadId();
 
     /**
      * Retrieves information about the current system.
      *
-     * @param addr The address of the SYSTEM_INFO structure that receives the information.
+     * @param addr Address of a SYSTEM_INFO structure.
+     * @see <a href="https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getnativesysteminfo">GetNativeSystemInfo</a>
      */
     void GetNativeSystemInfo(long addr);
 }

--- a/src/main/java/net/openhft/posix/internal/jnr/WinJNRPosixAPI.java
+++ b/src/main/java/net/openhft/posix/internal/jnr/WinJNRPosixAPI.java
@@ -7,8 +7,20 @@ import net.openhft.posix.PosixAPI;
 import static net.openhft.posix.internal.UnsafeMemory.UNSAFE;
 
 /**
- * Implementation of {@link PosixAPI} using JNR (Java Native Runtime) for Windows.
- * Provides POSIX-like methods for file and memory operations, leveraging the JNR library.
+ * Implementation of {@link PosixAPI} using JNR for Windows.
+ * Provides POSIX-style file and memory calls.
+ * <p>
+ * Windows lacks direct equivalents for several POSIX functions, so the
+ * following methods always report success and perform no action:
+ * <ul>
+ * <li>{@link #madvise(long, long, int)}</li>
+ * <li>{@link #msync(long, long, int)}</li>
+ * <li>{@link #fallocate(int, int, long, long)}</li>
+ * <li>{@link #ftruncate(int, long)}</li>
+ * <li>{@link #mmap(long, long, int, int, int, long)}</li>
+ * <li>{@link #munmap(long, long)}</li>
+ * <li>{@link #gettimeofday(long)}</li>
+ * </ul>
  */
 public final class WinJNRPosixAPI implements PosixAPI {
 

--- a/src/main/java/net/openhft/posix/internal/jnr/WinJNRPosixInterface.java
+++ b/src/main/java/net/openhft/posix/internal/jnr/WinJNRPosixInterface.java
@@ -1,7 +1,7 @@
 package net.openhft.posix.internal.jnr;
 
 /**
- * This interface defines the native methods for POSIX-like operations on Windows using JNR (Java Native Runtime).
+ * Native bindings for selected POSIX functions on Windows.
  */
 public interface WinJNRPosixInterface {
     // SetFilePointer
@@ -10,23 +10,26 @@ public interface WinJNRPosixInterface {
     /**
      * Allocates memory of a specified size.
      *
-     * @param size The size of the memory to allocate.
-     * @return The address of the allocated memory.
+     * @param size The number of bytes to allocate.
+     * @return The address of the allocated block.
+     * @see <a href="https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/malloc">malloc</a>
      */
     long malloc(long size);
 
     /**
-     * Frees allocated memory.
+     * Releases memory previously allocated with {@link #malloc(long)}.
      *
-     * @param ptr The address of the memory to free.
+     * @param ptr The address returned by {@link #malloc(long)}.
+     * @see <a href="https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/free">free</a>
      */
     void free(long ptr);
 
     /**
      * Closes a file descriptor.
      *
-     * @param fd The file descriptor to close.
+     * @param fd The descriptor to close.
      * @return 0 on success, -1 on error.
+     * @see <a href="https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/close">_close</a>
      */
     int _close(int fd);
 
@@ -34,19 +37,21 @@ public interface WinJNRPosixInterface {
      * Opens a file.
      *
      * @param path  The path to the file.
-     * @param flags The flags for opening the file.
-     * @param perm  The permissions for the file.
+     * @param flags Open flags.
+     * @param perm  Permission mask.
      * @return The file descriptor.
+     * @see <a href="https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/open-wopen">_open</a>
      */
     int _open(CharSequence path, int flags, int perm);
 
     /**
-     * Sets the file pointer to a specified location.
+     * Moves the file pointer.
      *
      * @param fd     The file descriptor.
-     * @param offset The offset to set the pointer to.
-     * @param origin The origin from where to set the offset.
-     * @return The new file pointer location.
+     * @param offset Number of bytes to move.
+     * @param origin Position from which to move.
+     * @return The new file pointer.
+     * @see <a href="https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/lseeki64">_lseeki64</a>
      */
     long _lseeki64(int fd, long offset, int origin);
 
@@ -54,9 +59,10 @@ public interface WinJNRPosixInterface {
      * Reads from a file descriptor.
      *
      * @param fd  The file descriptor.
-     * @param dst The destination address.
-     * @param len The number of bytes to read.
+     * @param dst Target buffer address.
+     * @param len Number of bytes to read.
      * @return The number of bytes read.
+     * @see <a href="https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/read">_read</a>
      */
     long _read(int fd, long dst, long len);
 
@@ -64,24 +70,27 @@ public interface WinJNRPosixInterface {
      * Writes to a file descriptor.
      *
      * @param fd  The file descriptor.
-     * @param src The source address.
-     * @param len The number of bytes to write.
+     * @param src Source buffer address.
+     * @param len Number of bytes to write.
      * @return The number of bytes written.
+     * @see <a href="https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/write">_write</a>
      */
     long _write(int fd, long src, long len);
 
     /**
-     * Gets the process ID.
+     * Returns the identifier of the current process.
      *
      * @return The process ID.
+     * @see <a href="https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/getpid">_getpid</a>
      */
     int _getpid();
 
     /**
-     * Returns the error message for a given error code.
+     * Converts an error number to a message string.
      *
      * @param errno The error code.
      * @return The error message.
+     * @see <a href="https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/strerror-wcsstrerror-mbscstrerror">strerror</a>
      */
     String strerror(int errno);
 }


### PR DESCRIPTION
## Summary
- describe which WinJNRPosixAPI calls are stubs
- add MSDN links for WinJNRPosixInterface
- add MSDN links for Kernel32JNRInterface

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*