### PR TITLE
Document JNI usage of UnsafeMemory

### DIFF
--- a/src/main/java/net/openhft/posix/internal/UnsafeMemory.java
+++ b/src/main/java/net/openhft/posix/internal/UnsafeMemory.java
@@ -5,8 +5,12 @@ import sun.misc.Unsafe;
 import java.lang.reflect.Field;
 
 /**
- * This enum provides access to the {@link Unsafe} class and some system memory properties.
- * It allows low-level, unsafe operations on memory, which are normally not accessible through standard Java APIs.
+ * Provides access to the {@link Unsafe} instance for low-level memory calls.
+ * <p>
+ * This utility is referenced by generated JNI layers and offers
+ * architecture hints such as {@link #IS64BIT}.  It exists solely as a
+ * holder for the native handle and should never be instantiated or
+ * extended directly.
  */
 public enum UnsafeMemory {
     // Empty enum to prevent instantiation


### PR DESCRIPTION
## Summary
- expand Javadoc for `UnsafeMemory` describing JNI usage

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*