### PR TITLE
Improve Javadoc summaries and mark version

### DIFF
--- a/src/main/java/net/openhft/posix/ClockId.java
+++ b/src/main/java/net/openhft/posix/ClockId.java
@@ -1,8 +1,9 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different clock IDs used in clock operations.
- * It defines the various clocks that can be used for timing and synchronization purposes.
+ * Clock IDs used for timing.
+ *
+ * @since 2.27
  */
 public enum ClockId {
     // The system-wide real-time clock
@@ -41,21 +42,10 @@ public enum ClockId {
     // The integer value representing the clock ID
     private final int value;
 
-    /**
-     * Constructor for ClockId.
-     *
-     * @param value The integer value representing the clock ID
-     */
     ClockId(int value) {
         this.value = value;
     }
 
-    /**
-     * This method is a getter for the value instance variable.
-     * It returns the current integer value of this ClockId object.
-     *
-     * @return The current integer value of this ClockId object
-     */
     public int value() {
         return value;
     }

--- a/src/main/java/net/openhft/posix/LockfFlag.java
+++ b/src/main/java/net/openhft/posix/LockfFlag.java
@@ -1,8 +1,9 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different flags for file locking (lockf) operations.
- * It defines the operations to be performed on file locks, such as locking, unlocking, and testing locks.
+ * Flags for lockf operations.
+ *
+ * @since 2.27
  */
 public enum LockfFlag {
     /**
@@ -34,21 +35,10 @@ public enum LockfFlag {
     // The integer value representing the lockf flag
     final int value;
 
-    /**
-     * Constructor for LockfFlag.
-     *
-     * @param value The integer value representing the lockf flag
-     */
     LockfFlag(int value) {
         this.value = value;
     }
 
-    /**
-     * This method is a getter for the value instance variable.
-     * It returns the current integer value of this LockfFlag object.
-     *
-     * @return The current integer value of this LockfFlag object
-     */
     public int value() {
         return value;
     }

--- a/src/main/java/net/openhft/posix/MAdviseFlag.java
+++ b/src/main/java/net/openhft/posix/MAdviseFlag.java
@@ -1,8 +1,9 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different flags for memory advice (madvise) operations.
- * It defines the advice to be given to the kernel about the intended usage pattern of memory.
+ * Advice flags for madvise.
+ *
+ * @since 2.27
  */
 public enum MAdviseFlag {
     // No further special treatment
@@ -59,21 +60,10 @@ public enum MAdviseFlag {
     // The integer value representing the madvise flag
     final int value;
 
-    /**
-     * Constructor for MAdviseFlag.
-     *
-     * @param value The integer value representing the madvise flag
-     */
     MAdviseFlag(int value) {
         this.value = value;
     }
 
-    /**
-     * This method is a getter for the value instance variable.
-     * It returns the current integer value of this MAdviseFlag object.
-     *
-     * @return The current integer value of this MAdviseFlag object
-     */
     public int value() {
         return value;
     }

--- a/src/main/java/net/openhft/posix/MMapFlag.java
+++ b/src/main/java/net/openhft/posix/MMapFlag.java
@@ -1,8 +1,9 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different flags for mmap operations.
- * It defines the flags for memory mapping operations, including shared and private mappings.
+ * Flags for mmap operations.
+ *
+ * @since 2.27
  */
 public enum MMapFlag {
     // Memory mapping to be shared with other processes
@@ -14,21 +15,10 @@ public enum MMapFlag {
     // The integer value representing the mmap flag
     private int value;
 
-    /**
-     * Constructor for MMapFlag.
-     *
-     * @param value The integer value representing the mmap flag
-     */
     MMapFlag(int value) {
         this.value = value;
     }
 
-    /**
-     * This method is a getter for the value instance variable.
-     * It returns the current integer value of this MMapFlag object.
-     *
-     * @return The current integer value of this MMapFlag object
-     */
     public int value() {
         return value;
     }

--- a/src/main/java/net/openhft/posix/MMapProt.java
+++ b/src/main/java/net/openhft/posix/MMapProt.java
@@ -1,8 +1,9 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different memory protection options for mmap.
- * It defines the protection levels for memory mapping operations, including read, write, execute, and none.
+ * Protection flags for mmap.
+ *
+ * @since 2.27
  */
 public enum MMapProt {
     // Memory protection to allow read access
@@ -26,21 +27,10 @@ public enum MMapProt {
     // The integer value representing the memory protection level
     final int value;
 
-    /**
-     * Constructor for MMapProt.
-     *
-     * @param value The integer value representing the memory protection level
-     */
     MMapProt(int value) {
         this.value = value;
     }
 
-    /**
-     * This method is a getter for the value instance variable.
-     * It returns the current integer value of this MMapProt object.
-     *
-     * @return The current integer value of this MMapProt object
-     */
     public int value() {
         return value;
     }

--- a/src/main/java/net/openhft/posix/MSyncFlag.java
+++ b/src/main/java/net/openhft/posix/MSyncFlag.java
@@ -1,8 +1,9 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different flags for memory synchronization (msync) operations.
- * It defines the flags used to control the behavior of memory synchronization operations.
+ * Flags for msync.
+ *
+ * @since 2.27
  */
 public enum MSyncFlag {
     /**
@@ -23,21 +24,10 @@ public enum MSyncFlag {
     // The integer value representing the msync flag
     private final int value;
 
-    /**
-     * Constructor for MSyncFlag.
-     *
-     * @param value The integer value representing the msync flag
-     */
     MSyncFlag(int value) {
         this.value = value;
     }
 
-    /**
-     * This method is a getter for the value instance variable.
-     * It returns the current integer value of this MSyncFlag object.
-     *
-     * @return The current integer value of this MSyncFlag object
-     */
     public int value() {
         return value;
     }

--- a/src/main/java/net/openhft/posix/Mapping.java
+++ b/src/main/java/net/openhft/posix/Mapping.java
@@ -3,8 +3,9 @@ package net.openhft.posix;
 import net.openhft.posix.internal.UnsafeMemory;
 
 /**
- * This class represents a memory mapping in the /proc/[pid]/maps file.
- * It parses and stores the details of a single memory mapping.
+ * Represents an entry from /proc/[pid]/maps.
+ *
+ * @since 2.27
  */
 public final class Mapping {
     // The start address of the memory mapping
@@ -50,74 +51,34 @@ public final class Mapping {
         toString = line;
     }
 
-    /**
-     * Returns the start address of the memory mapping.
-     *
-     * @return The start address of the memory mapping.
-     */
     public long addr() {
         return addr;
     }
 
-    /**
-     * Returns the length of the memory mapping.
-     *
-     * @return The length of the memory mapping.
-     */
     public long length() {
         return length;
     }
 
-    /**
-     * Returns the offset into the file/VM object to which the memory mapping refers.
-     *
-     * @return The offset into the file/VM object.
-     */
     public long offset() {
         return offset;
     }
 
-    /**
-     * Returns the inode on the device.
-     *
-     * @return The inode on the device.
-     */
     public long inode() {
         return inode;
     }
 
-    /**
-     * Returns the permissions of the memory mapping.
-     *
-     * @return The permissions of the memory mapping.
-     */
     public String perms() {
         return perms;
     }
 
-    /**
-     * Returns the device (major:minor) of the memory mapping.
-     *
-     * @return The device of the memory mapping.
-     */
     public String device() {
         return device;
     }
 
-    /**
-     * Returns the file path associated with the memory mapping.
-     *
-     * @return The file path associated with the memory mapping.
-     */
     public String path() {
         return path;
     }
 
-    /**
-     * Returns the original line from the /proc/[pid]/maps file.
-     *
-     * @return The original line from the /proc/[pid]/maps file.
-     */
     @Override
     public String toString() {
         return toString;

--- a/src/main/java/net/openhft/posix/MclFlag.java
+++ b/src/main/java/net/openhft/posix/MclFlag.java
@@ -1,8 +1,9 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different flags for memory locking (mlockall) operations.
- * It defines the flags used to control how pages are locked in memory.
+ * Flags for mlockall.
+ *
+ * @since 2.27
  */
 public enum MclFlag {
     // Lock all current pages in memory
@@ -20,21 +21,10 @@ public enum MclFlag {
     // The integer code representing the mlockall flag
     private int code;
 
-    /**
-     * Constructor for MclFlag.
-     *
-     * @param code The integer code representing the mlockall flag
-     */
     MclFlag(int code) {
         this.code = code;
     }
 
-    /**
-     * This method is a getter for the code instance variable.
-     * It returns the current integer code of this MclFlag object.
-     *
-     * @return The current integer code of this MclFlag object
-     */
     public int code() {
         return code;
     }

--- a/src/main/java/net/openhft/posix/OpenFlag.java
+++ b/src/main/java/net/openhft/posix/OpenFlag.java
@@ -1,8 +1,9 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different flags for opening files (open).
- * It defines the flags used to control the behavior of file opening operations.
+ * Flags for opening files.
+ *
+ * @since 2.27
  */
 public enum OpenFlag {
     // Open for reading only
@@ -44,21 +45,10 @@ public enum OpenFlag {
     // The integer value representing the open flag
     final int value;
 
-    /**
-     * Constructor for OpenFlag.
-     *
-     * @param value The integer value representing the open flag
-     */
     OpenFlag(int value) {
         this.value = value;
     }
 
-    /**
-     * This method is a getter for the value instance variable.
-     * It returns the current integer value of this OpenFlag object.
-     *
-     * @return The current integer value of this OpenFlag object
-     */
     public int value() {
         return value;
     }

--- a/src/main/java/net/openhft/posix/PosixAPI.java
+++ b/src/main/java/net/openhft/posix/PosixAPI.java
@@ -10,8 +10,9 @@ import java.io.InputStreamReader;
 import static net.openhft.posix.internal.UnsafeMemory.UNSAFE;
 
 /**
- * This interface provides a set of methods for interacting with POSIX APIs.
- * It includes methods for file operations, memory management, and process scheduling.
+ * POSIX system access interface.
+ *
+ * @since 2.27
  */
 public interface PosixAPI {
 

--- a/src/main/java/net/openhft/posix/PosixRuntimeException.java
+++ b/src/main/java/net/openhft/posix/PosixRuntimeException.java
@@ -1,8 +1,9 @@
 package net.openhft.posix;
 
 /**
- * This class represents a runtime exception specific to POSIX operations.
- * It extends the standard {@link RuntimeException} to provide more specific error handling for POSIX-related errors.
+ * Runtime exception for POSIX operations.
+ *
+ * @since 2.27
  */
 public class PosixRuntimeException extends RuntimeException {
     // Serialization version UID for ensuring compatibility during deserialization

--- a/src/main/java/net/openhft/posix/ProcMaps.java
+++ b/src/main/java/net/openhft/posix/ProcMaps.java
@@ -11,8 +11,9 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.toList;
 
 /**
- * This class provides methods to read and parse the memory mappings from the /proc filesystem on Linux.
- * It allows users to retrieve memory mappings for the current process or a specified process ID (PID).
+ * Parses /proc maps to list memory mappings.
+ *
+ * @since 2.27
  */
 public final class ProcMaps {
     // A list to hold the memory mappings

--- a/src/main/java/net/openhft/posix/WhenceFlag.java
+++ b/src/main/java/net/openhft/posix/WhenceFlag.java
@@ -1,8 +1,9 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different flags for seeking within a file (whence).
- * It defines the options used to set the file offset for read/write operations.
+ * Whence flags for file seeking.
+ *
+ * @since 2.27
  */
 public enum WhenceFlag {
     /**
@@ -36,21 +37,10 @@ public enum WhenceFlag {
     // The integer value representing the whence flag
     private final int value;
 
-    /**
-     * Constructor for WhenceFlag.
-     *
-     * @param value The integer value representing the whence flag
-     */
     WhenceFlag(int value) {
         this.value = value;
     }
 
-    /**
-     * This method is a getter for the value instance variable.
-     * It returns the current integer value of this WhenceFlag object.
-     *
-     * @return The current integer value of this WhenceFlag object
-     */
     public int value() {
         return value;
     }

--- a/src/main/java/net/openhft/posix/internal/PosixAPIHolder.java
+++ b/src/main/java/net/openhft/posix/internal/PosixAPIHolder.java
@@ -7,8 +7,9 @@ import net.openhft.posix.internal.jnr.WinJNRPosixAPI;
 import net.openhft.posix.internal.noop.NoOpPosixAPI;
 
 /**
- * This class holds the instance of the {@link PosixAPI} to be used.
- * It loads the appropriate PosixAPI implementation based on the native platform.
+ * Loads the best {@link PosixAPI} for the host.
+ *
+ * @since 2.27
  */
 public class PosixAPIHolder {
     // The PosixAPI instance to be used

--- a/src/main/java/net/openhft/posix/internal/UnsafeMemory.java
+++ b/src/main/java/net/openhft/posix/internal/UnsafeMemory.java
@@ -5,8 +5,9 @@ import sun.misc.Unsafe;
 import java.lang.reflect.Field;
 
 /**
- * This enum provides access to the {@link Unsafe} class and some system memory properties.
- * It allows low-level, unsafe operations on memory, which are normally not accessible through standard Java APIs.
+ * Access to {@link Unsafe} and memory traits.
+ *
+ * @since 2.27
  */
 public enum UnsafeMemory {
     // Empty enum to prevent instantiation

--- a/src/main/java/net/openhft/posix/internal/core/Jvm.java
+++ b/src/main/java/net/openhft/posix/internal/core/Jvm.java
@@ -3,7 +3,9 @@ package net.openhft.posix.internal.core;
 import net.openhft.posix.internal.UnsafeMemory;
 
 /**
- * Utility class to access information about the JVM.
+ * Utilities for querying JVM details.
+ *
+ * @since 2.27
  */
 public final class Jvm {
 

--- a/src/main/java/net/openhft/posix/internal/core/OS.java
+++ b/src/main/java/net/openhft/posix/internal/core/OS.java
@@ -3,7 +3,9 @@ package net.openhft.posix.internal.core;
 import static net.openhft.posix.internal.core.Jvm.OS_ARCH;
 
 /**
- * Utility class to access information about the operating system.
+ * Utilities for querying the host OS.
+ *
+ * @since 2.27
  */
 public final class OS {
 

--- a/src/main/java/net/openhft/posix/internal/jna/JNAPosixAPI.java
+++ b/src/main/java/net/openhft/posix/internal/jna/JNAPosixAPI.java
@@ -7,8 +7,9 @@ import com.sun.jna.Pointer;
 import net.openhft.posix.PosixAPI;
 
 /**
- * Abstract class implementing {@link PosixAPI} using JNA (Java Native Access).
- * It provides methods for memory mapping operations, leveraging the JNA library.
+ * Partial {@link PosixAPI} implementation using JNA.
+ *
+ * @since 2.27
  */
 public abstract class JNAPosixAPI implements PosixAPI {
     private static final Pointer NULL = Pointer.createConstant(0);

--- a/src/main/java/net/openhft/posix/internal/jna/JNAPosixInterface.java
+++ b/src/main/java/net/openhft/posix/internal/jna/JNAPosixInterface.java
@@ -3,8 +3,9 @@ package net.openhft.posix.internal.jna;
 import com.sun.jna.Pointer;
 
 /**
- * This class defines the native methods for POSIX-like operations using JNA (Java Native Access).
- * It provides methods for memory mapping operations.
+ * Native methods for POSIX operations via JNA.
+ *
+ * @since 2.27
  */
 public class JNAPosixInterface {
 

--- a/src/main/java/net/openhft/posix/internal/jnr/JNRPosixAPI.java
+++ b/src/main/java/net/openhft/posix/internal/jnr/JNRPosixAPI.java
@@ -18,8 +18,9 @@ import java.util.function.IntSupplier;
 import static net.openhft.posix.internal.UnsafeMemory.UNSAFE;
 
 /**
- * Implementation of {@link PosixAPI} using JNR (Java Native Runtime).
- * Provides POSIX-like methods for file and memory operations, leveraging the JNR library.
+ * PosixAPI implementation using JNR.
+ *
+ * @since 2.27
  */
 public final class JNRPosixAPI implements PosixAPI {
 

--- a/src/main/java/net/openhft/posix/internal/jnr/JNRPosixInterface.java
+++ b/src/main/java/net/openhft/posix/internal/jnr/JNRPosixInterface.java
@@ -3,8 +3,9 @@ package net.openhft.posix.internal.jnr;
 import jnr.ffi.Pointer;
 
 /**
- * This interface defines the native methods for POSIX-like operations using JNR (Java Native Runtime).
- * It provides methods for file and memory operations, process scheduling, and system information retrieval.
+ * Native POSIX methods via JNR.
+ *
+ * @since 2.27
  */
 public interface JNRPosixInterface {
     int open(CharSequence path, int flags, int perm);

--- a/src/main/java/net/openhft/posix/internal/jnr/Kernel32JNRInterface.java
+++ b/src/main/java/net/openhft/posix/internal/jnr/Kernel32JNRInterface.java
@@ -1,7 +1,9 @@
 package net.openhft.posix.internal.jnr;
 
 /**
- * This interface defines the native methods for interacting with the Kernel32 library on Windows using JNR (Java Native Runtime).
+ * Native Kernel32 methods via JNR.
+ *
+ * @since 2.27
  */
 public interface Kernel32JNRInterface {
 

--- a/src/main/java/net/openhft/posix/internal/jnr/WinJNRPosixAPI.java
+++ b/src/main/java/net/openhft/posix/internal/jnr/WinJNRPosixAPI.java
@@ -7,8 +7,9 @@ import net.openhft.posix.PosixAPI;
 import static net.openhft.posix.internal.UnsafeMemory.UNSAFE;
 
 /**
- * Implementation of {@link PosixAPI} using JNR (Java Native Runtime) for Windows.
- * Provides POSIX-like methods for file and memory operations, leveraging the JNR library.
+ * PosixAPI implementation via JNR for Windows.
+ *
+ * @since 2.27
  */
 public final class WinJNRPosixAPI implements PosixAPI {
 

--- a/src/main/java/net/openhft/posix/internal/jnr/WinJNRPosixInterface.java
+++ b/src/main/java/net/openhft/posix/internal/jnr/WinJNRPosixInterface.java
@@ -1,7 +1,9 @@
 package net.openhft.posix.internal.jnr;
 
 /**
- * This interface defines the native methods for POSIX-like operations on Windows using JNR (Java Native Runtime).
+ * Native POSIX methods for Windows via JNR.
+ *
+ * @since 2.27
  */
 public interface WinJNRPosixInterface {
     // SetFilePointer

--- a/src/main/java/net/openhft/posix/internal/noop/NoOpPosixAPI.java
+++ b/src/main/java/net/openhft/posix/internal/noop/NoOpPosixAPI.java
@@ -4,8 +4,9 @@ import net.openhft.posix.PosixAPI;
 import net.openhft.posix.PosixRuntimeException;
 
 /**
- * No-Op Posix implementation. Each method either does nothing and returns 0 (indicating no error)
- * or throws a {@link PosixRuntimeException} indicating that the POSIX implementation is missing.
+ * PosixAPI stub that does nothing or throws.
+ *
+ * @since 2.27
  */
 public class NoOpPosixAPI implements PosixAPI {
     // The reason why this No-Op implementation is used

--- a/src/main/java/net/openhft/posix/internal/raw/RawPosixAPI.java
+++ b/src/main/java/net/openhft/posix/internal/raw/RawPosixAPI.java
@@ -3,8 +3,9 @@ package net.openhft.posix.internal.raw;
 import net.openhft.posix.PosixAPI;
 
 /**
- * This abstract class serves as a base for raw POSIX API implementations.
- * It implements the {@link PosixAPI} interface, providing a foundation for low-level POSIX operations.
+ * Base class for raw POSIX API implementations.
+ *
+ * @since 2.27
  */
 public abstract class RawPosixAPI implements PosixAPI {
     // This class intentionally left blank as it serves as a base for specific raw POSIX API implementations


### PR DESCRIPTION
## Summary
- tidy Javadoc across public types
- remove repetitive getter comments
- tag all types with `@since 2.27`

## Testing
- `mvn -q verify` *(fails: command not found)*
- `mvn javadoc:javadoc` *(fails: command not found)*