### PR TITLE
Improve documentation and clean up Javadoc

### DIFF
--- a/src/main/java/net/openhft/posix/ClockId.java
+++ b/src/main/java/net/openhft/posix/ClockId.java
@@ -1,60 +1,60 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different clock IDs used in clock operations.
- * It defines the various clocks that can be used for timing and synchronization purposes.
+ * Identifiers for {@code clock_gettime(2)}.
+ *
+ * @see <a href="https://man7.org/linux/man-pages/man2/clock_gettime.2.html">clock_gettime(2)</a>
+ * @since 2.27
  */
 public enum ClockId {
-    // The system-wide real-time clock
+    /** System-wide real-time clock. */
     CLOCK_REALTIME(0),
 
-    // The monotonic clock, which cannot be set and represents monotonic time since some unspecified starting point
+    /** Monotonic clock. */
     CLOCK_MONOTONIC(1),
 
-    // The clock measuring the CPU time consumed by the process
+    /** CPU time consumed by the process. */
     CLOCK_PROCESS_CPUTIME_ID(2),
 
-    // The clock measuring the CPU time consumed by the thread
+    /** CPU time consumed by the thread. */
     CLOCK_THREAD_CPUTIME_ID(3),
 
-    // The raw monotonic clock, without NTP adjustments
+    /** Monotonic clock without NTP adjustments. */
     CLOCK_MONOTONIC_RAW(4),
 
-    // The system-wide real-time clock, but faster and less accurate
+    /** Faster but coarse real-time clock. */
     CLOCK_REALTIME_COARSE(5),
 
-    // The coarse monotonic clock, but faster and less accurate
+    /** Faster but coarse monotonic clock. */
     CLOCK_MONOTONIC_COARSE(6),
 
-    // The monotonic clock that includes time spent in suspend
+    /** Monotonic clock including suspend time. */
     CLOCK_BOOTTIME(7),
 
-    // The system-wide real-time clock used to set alarms
+    /** Real-time clock used for alarms. */
     CLOCK_REALTIME_ALARM(8),
 
-    // The boot-time clock used to set alarms
+    /** Boot-time clock used for alarms. */
     CLOCK_BOOTTIME_ALARM(9),
 
-    // The SGI cycle counter
+    /** SGI cycle counter. */
     CLOCK_SGI_CYCLE(10);
 
-    // The integer value representing the clock ID
+    /** Native constant value. */
     private final int value;
 
     /**
-     * Constructor for ClockId.
-     *
-     * @param value The integer value representing the clock ID
+     * @param value native constant value
      */
     ClockId(int value) {
         this.value = value;
     }
 
     /**
-     * This method is a getter for the value instance variable.
-     * It returns the current integer value of this ClockId object.
+     * Constant to pass to {@code clock_gettime}.
      *
-     * @return The current integer value of this ClockId object
+     * @return integer value
+     * @since 2.27
      */
     public int value() {
         return value;

--- a/src/main/java/net/openhft/posix/LockfFlag.java
+++ b/src/main/java/net/openhft/posix/LockfFlag.java
@@ -1,53 +1,39 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different flags for file locking (lockf) operations.
- * It defines the operations to be performed on file locks, such as locking, unlocking, and testing locks.
+ * Operations for {@code lockf(3)}.
+ *
+ * @see <a href="https://man7.org/linux/man-pages/man3/lockf.3.html">lockf(3)</a>
+ * @since 2.27
  */
 public enum LockfFlag {
-    /**
-     * Unlock the indicated section of the file.
-     * This may cause a locked section to be split into two locked sections.
-     */
+    /** Release the specified section. */
     F_ULOCK(0),
 
-    /**
-     * Set an exclusive lock on the specified section of the file.
-     * If (part of) this section is already locked, the call blocks until the previous lock is released.
-     * If this section overlaps an earlier locked section, both are merged.
-     * File locks are released as soon as the process holding the locks closes some file descriptor for the file.
-     * A child process does not inherit these locks.
-     */
+    /** Exclusive lock on the section. Blocks until available. */
     F_LOCK(1),
 
-    /**
-     * Same as F_LOCK but the call never blocks and returns an error instead if the file is already locked.
-     */
+    /** Non-blocking exclusive lock. */
     F_TLOCK(2),
 
-    /**
-     * Test the lock: return 0 if the specified section is unlocked or locked by this process;
-     * return -1, set errno to EAGAIN (EACCES on some other systems), if another process holds a lock.
-     */
+    /** Test whether a lock is held by another process. */
     F_TEST(3);
 
-    // The integer value representing the lockf flag
+    /** Native constant value. */
     final int value;
 
     /**
-     * Constructor for LockfFlag.
-     *
-     * @param value The integer value representing the lockf flag
+     * @param value native constant value
      */
     LockfFlag(int value) {
         this.value = value;
     }
 
     /**
-     * This method is a getter for the value instance variable.
-     * It returns the current integer value of this LockfFlag object.
+     * Constant to pass to {@code lockf}.
      *
-     * @return The current integer value of this LockfFlag object
+     * @return integer value
+     * @since 2.27
      */
     public int value() {
         return value;

--- a/src/main/java/net/openhft/posix/MAdviseFlag.java
+++ b/src/main/java/net/openhft/posix/MAdviseFlag.java
@@ -1,78 +1,78 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different flags for memory advice (madvise) operations.
- * It defines the advice to be given to the kernel about the intended usage pattern of memory.
+ * Advice flags for {@code madvise(2)}.
+ *
+ * @see <a href="https://man7.org/linux/man-pages/man2/madvise.2.html">madvise(2)</a>
+ * @since 2.27
  */
 public enum MAdviseFlag {
-    // No further special treatment
+    /** No special treatment. */
     MADV_NORMAL(0),
 
-    // Expect random page references
+    /** Expect random page references. */
     MADV_RANDOM(1),
 
-    // Expect sequential page references
+    /** Expect sequential page references. */
     MADV_SEQUENTIAL(2),
 
-    // Will need these pages
+    /** Will need these pages. */
     MADV_WILLNEED(3),
 
-    // Don't need these pages
+    /** Do not need these pages. */
     MADV_DONTNEED(4),
 
-    // Free pages only if memory pressure
+    /** Free pages only under memory pressure. */
     MADV_FREE(8),
 
-    // Remove these pages and resources
+    /** Remove these pages and resources. */
     MADV_REMOVE(9),
 
-    // Do not inherit across fork
+    /** Do not inherit across fork. */
     MADV_DONTFORK(10),
 
-    // Do inherit across fork
+    /** Do inherit across fork. */
     MADV_DOFORK(11),
 
-    // KSM may merge identical pages
+    /** KSM may merge identical pages. */
     MADV_MERGEABLE(12),
 
-    // KSM may not merge identical pages
+    /** KSM may not merge identical pages. */
     MADV_UNMERGEABLE(13),
 
-    // Worth backing with hugepages
+    /** Worth backing with hugepages. */
     MADV_HUGEPAGE(14),
 
-    // Not worth backing with hugepages
+    /** Not worth backing with hugepages. */
     MADV_NOHUGEPAGE(15),
 
-    // Explicitly exclude from the core dump, overrides the coredump filter bits
+    /** Exclude from core dump. */
     MADV_DONTDUMP(16),
 
-    // Clear the MADV_DONTDUMP flag
+    /** Clear the {@link #MADV_DONTDUMP} flag. */
     MADV_DODUMP(17),
 
-    // Zero memory on fork, child only
+    /** Zero memory on fork for the child only. */
     MADV_WIPEONFORK(18),
 
-    // Undo MADV_WIPEONFORK
+    /** Undo {@link #MADV_WIPEONFORK}. */
     MADV_KEEPONFORK(19);
 
-    // The integer value representing the madvise flag
+    /** Native constant value. */
     final int value;
 
     /**
-     * Constructor for MAdviseFlag.
-     *
-     * @param value The integer value representing the madvise flag
+     * @param value native constant value
      */
     MAdviseFlag(int value) {
         this.value = value;
     }
 
     /**
-     * This method is a getter for the value instance variable.
-     * It returns the current integer value of this MAdviseFlag object.
+     * Constant to pass to {@code madvise}.
      *
-     * @return The current integer value of this MAdviseFlag object
+     * @return integer value
+     * @since 2.27
      */
     public int value() {
         return value;

--- a/src/main/java/net/openhft/posix/MMapFlag.java
+++ b/src/main/java/net/openhft/posix/MMapFlag.java
@@ -1,33 +1,33 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different flags for mmap operations.
- * It defines the flags for memory mapping operations, including shared and private mappings.
+ * Mapping flags for {@code mmap(2)}.
+ *
+ * @see <a href="https://man7.org/linux/man-pages/man2/mmap.2.html">mmap(2)</a>
+ * @since 2.27
  */
 public enum MMapFlag {
-    // Memory mapping to be shared with other processes
+    /** Mapping visible to other processes. */
     SHARED(1),
 
-    // Memory mapping to be private to the process
+    /** Mapping private to the process. */
     PRIVATE(2);
 
-    // The integer value representing the mmap flag
+    /** Native constant value. */
     private int value;
 
     /**
-     * Constructor for MMapFlag.
-     *
-     * @param value The integer value representing the mmap flag
+     * @param value native constant value
      */
     MMapFlag(int value) {
         this.value = value;
     }
 
     /**
-     * This method is a getter for the value instance variable.
-     * It returns the current integer value of this MMapFlag object.
+     * Constant to pass to {@code mmap}.
      *
-     * @return The current integer value of this MMapFlag object
+     * @return integer value
+     * @since 2.27
      */
     public int value() {
         return value;

--- a/src/main/java/net/openhft/posix/MMapProt.java
+++ b/src/main/java/net/openhft/posix/MMapProt.java
@@ -1,45 +1,45 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different memory protection options for mmap.
- * It defines the protection levels for memory mapping operations, including read, write, execute, and none.
+ * Protection flags for {@code mmap(2)}.
+ *
+ * @see <a href="https://man7.org/linux/man-pages/man2/mmap.2.html">mmap(2)</a>
+ * @since 2.27
  */
 public enum MMapProt {
-    // Memory protection to allow read access
+    /** Allow read access. */
     PROT_READ(1),
 
-    // Memory protection to allow write access
+    /** Allow write access. */
     PROT_WRITE(2),
 
-    // Memory protection to allow both read and write access
+    /** Allow read and write access. */
     PROT_READ_WRITE(3),
 
-    // Memory protection to allow execute access
+    /** Allow execute access. */
     PROT_EXEC(4),
 
-    // Memory protection to allow both execute and read access
+    /** Allow execute and read access. */
     PROT_EXEC_READ(5),
 
-    // Memory protection to allow no access
+    /** No access. */
     PROT_NONE(8);
 
-    // The integer value representing the memory protection level
+    /** Native constant value. */
     final int value;
 
     /**
-     * Constructor for MMapProt.
-     *
-     * @param value The integer value representing the memory protection level
+     * @param value native constant value
      */
     MMapProt(int value) {
         this.value = value;
     }
 
     /**
-     * This method is a getter for the value instance variable.
-     * It returns the current integer value of this MMapProt object.
+     * Constant to pass to {@code mmap}.
      *
-     * @return The current integer value of this MMapProt object
+     * @return integer value
+     * @since 2.27
      */
     public int value() {
         return value;

--- a/src/main/java/net/openhft/posix/MSyncFlag.java
+++ b/src/main/java/net/openhft/posix/MSyncFlag.java
@@ -1,42 +1,36 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different flags for memory synchronization (msync) operations.
- * It defines the flags used to control the behavior of memory synchronization operations.
+ * Flags for {@code msync(2)}.
+ *
+ * @see <a href="https://man7.org/linux/man-pages/man2/msync.2.html">msync(2)</a>
+ * @since 2.27
  */
 public enum MSyncFlag {
-    /**
-     * Sync memory asynchronously.
-     */
+    /** Sync memory asynchronously. */
     MS_ASYNC(1),
 
-    /**
-     * Invalidate the caches.
-     */
+    /** Invalidate caches. */
     MS_INVALIDATE(2),
 
-    /**
-     * Synchronous memory sync.
-     */
+    /** Synchronous memory sync. */
     MS_SYNC(4);
 
-    // The integer value representing the msync flag
+    /** Native constant value. */
     private final int value;
 
     /**
-     * Constructor for MSyncFlag.
-     *
-     * @param value The integer value representing the msync flag
+     * @param value native constant value
      */
     MSyncFlag(int value) {
         this.value = value;
     }
 
     /**
-     * This method is a getter for the value instance variable.
-     * It returns the current integer value of this MSyncFlag object.
+     * Constant to pass to {@code msync}.
      *
-     * @return The current integer value of this MSyncFlag object
+     * @return integer value
+     * @since 2.27
      */
     public int value() {
         return value;

--- a/src/main/java/net/openhft/posix/Mapping.java
+++ b/src/main/java/net/openhft/posix/Mapping.java
@@ -3,8 +3,10 @@ package net.openhft.posix;
 import net.openhft.posix.internal.UnsafeMemory;
 
 /**
- * This class represents a memory mapping in the /proc/[pid]/maps file.
- * It parses and stores the details of a single memory mapping.
+ * Representation of one line from {@code /proc/[pid]/maps}.
+ *
+ * @see <a href="https://man7.org/linux/man-pages/man5/proc.5.html">proc(5)</a>
+ * @since 2.27
  */
 public final class Mapping {
     // The start address of the memory mapping
@@ -32,9 +34,10 @@ public final class Mapping {
     private final String toString;
 
     /**
-     * Constructs a Mapping object by parsing a line from the /proc/[pid]/maps file.
+     * Parses a mapping line from {@code /proc/[pid]/maps}.
      *
-     * @param line A line from the /proc/[pid]/maps file.
+     * @param line textual line from the maps file
+     * @since 2.27
      */
     public Mapping(String line) {
         String[] parts = line.split(" +");
@@ -50,74 +53,42 @@ public final class Mapping {
         toString = line;
     }
 
-    /**
-     * Returns the start address of the memory mapping.
-     *
-     * @return The start address of the memory mapping.
-     */
+    /** Start address of the mapping. */
     public long addr() {
         return addr;
     }
 
-    /**
-     * Returns the length of the memory mapping.
-     *
-     * @return The length of the memory mapping.
-     */
+    /** Length of the mapping. */
     public long length() {
         return length;
     }
 
-    /**
-     * Returns the offset into the file/VM object to which the memory mapping refers.
-     *
-     * @return The offset into the file/VM object.
-     */
+    /** Offset into the file or VM object. */
     public long offset() {
         return offset;
     }
 
-    /**
-     * Returns the inode on the device.
-     *
-     * @return The inode on the device.
-     */
+    /** Inode number. */
     public long inode() {
         return inode;
     }
 
-    /**
-     * Returns the permissions of the memory mapping.
-     *
-     * @return The permissions of the memory mapping.
-     */
+    /** Permission string such as {@code r-xp}. */
     public String perms() {
         return perms;
     }
 
-    /**
-     * Returns the device (major:minor) of the memory mapping.
-     *
-     * @return The device of the memory mapping.
-     */
+    /** Device in {@code major:minor} form. */
     public String device() {
         return device;
     }
 
-    /**
-     * Returns the file path associated with the memory mapping.
-     *
-     * @return The file path associated with the memory mapping.
-     */
+    /** File path of the mapping if any. */
     public String path() {
         return path;
     }
 
-    /**
-     * Returns the original line from the /proc/[pid]/maps file.
-     *
-     * @return The original line from the /proc/[pid]/maps file.
-     */
+    /** Original line from the maps file. */
     @Override
     public String toString() {
         return toString;

--- a/src/main/java/net/openhft/posix/MclFlag.java
+++ b/src/main/java/net/openhft/posix/MclFlag.java
@@ -1,39 +1,39 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different flags for memory locking (mlockall) operations.
- * It defines the flags used to control how pages are locked in memory.
+ * Flags for {@code mlockall(2)}.
+ *
+ * @see <a href="https://man7.org/linux/man-pages/man2/mlockall.2.html">mlockall(2)</a>
+ * @since 2.27
  */
 public enum MclFlag {
-    // Lock all current pages in memory
+    /** Lock current pages in memory. */
     MclCurrent(1),
 
-    // Lock all future pages in memory
+    /** Lock future pages in memory. */
     MclFuture(2),
 
-    // Lock all current pages in memory on fault
+    /** Lock current pages on fault. */
     MclCurrentOnFault(1 + 4),
 
-    // Lock all future pages in memory on fault
+    /** Lock future pages on fault. */
     MclFutureOnFault(2 + 4);
 
-    // The integer code representing the mlockall flag
+    /** Native constant value. */
     private int code;
 
     /**
-     * Constructor for MclFlag.
-     *
-     * @param code The integer code representing the mlockall flag
+     * @param code native constant value
      */
     MclFlag(int code) {
         this.code = code;
     }
 
     /**
-     * This method is a getter for the code instance variable.
-     * It returns the current integer code of this MclFlag object.
+     * Constant to pass to {@code mlockall}.
      *
-     * @return The current integer code of this MclFlag object
+     * @return integer value
+     * @since 2.27
      */
     public int code() {
         return code;

--- a/src/main/java/net/openhft/posix/OpenFlag.java
+++ b/src/main/java/net/openhft/posix/OpenFlag.java
@@ -1,63 +1,63 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different flags for opening files (open).
- * It defines the flags used to control the behavior of file opening operations.
+ * Flags for {@code open(2)}.
+ *
+ * @see <a href="https://man7.org/linux/man-pages/man2/open.2.html">open(2)</a>
+ * @since 2.27
  */
 public enum OpenFlag {
-    // Open for reading only
+    /** Open for reading only. */
     O_RDONLY(0x0000),
 
-    // Open for writing only
+    /** Open for writing only. */
     O_WRONLY(0x0001),
 
-    // Open for reading and writing
+    /** Open for reading and writing. */
     O_RDWR(0x0002),
 
-    // No delay (non-blocking mode)
+    /** Non-blocking mode. */
     O_NONBLOCK(0x0004),
 
-    // Set append mode
+    /** Append mode. */
     O_APPEND(0x0008),
 
-    // Open with shared file lock
+    /** Open with shared lock. */
     O_SHLOCK(0x0010),
 
-    // Open with exclusive file lock
+    /** Open with exclusive lock. */
     O_EXLOCK(0x0020),
 
-    // Signal pgrp when data is ready (asynchronous mode)
+    /** Signal when data is ready. */
     O_ASYNC(0x0040),
 
-    // Synchronous writes
+    /** Synchronous writes. */
     O_FSYNC(0x0080),
 
-    // Create if non-existent
+    /** Create if missing. */
     O_CREAT(0x0200),
 
-    // Truncate to zero length
+    /** Truncate to zero length. */
     O_TRUNC(0x0400),
 
-    // Error if already exists
+    /** Error if already exists. */
     O_EXCL(0x0800);
 
-    // The integer value representing the open flag
+    /** Native constant value. */
     final int value;
 
     /**
-     * Constructor for OpenFlag.
-     *
-     * @param value The integer value representing the open flag
+     * @param value native constant value
      */
     OpenFlag(int value) {
         this.value = value;
     }
 
     /**
-     * This method is a getter for the value instance variable.
-     * It returns the current integer value of this OpenFlag object.
+     * Constant to pass to {@code open}.
      *
-     * @return The current integer value of this OpenFlag object
+     * @return integer value
+     * @since 2.27
      */
     public int value() {
         return value;

--- a/src/main/java/net/openhft/posix/PosixAPI.java
+++ b/src/main/java/net/openhft/posix/PosixAPI.java
@@ -10,8 +10,13 @@ import java.io.InputStreamReader;
 import static net.openhft.posix.internal.UnsafeMemory.UNSAFE;
 
 /**
- * This interface provides a set of methods for interacting with POSIX APIs.
- * It includes methods for file operations, memory management, and process scheduling.
+ * Facade over a small subset of POSIX needed by Chronicle libraries. The API covers
+ * file descriptors, memory mapping and CPU-affinity helpers but it is not a complete
+ * POSIX implementation. None of the methods are async-signal-safe and therefore must
+ * not be invoked from a signal handler.
+ *
+ * @see <a href="../../adoc/project-requirements.adoc#posix-fn-001">POSIX-FN-001</a>
+ * @since 2.27
  */
 public interface PosixAPI {
 
@@ -31,112 +36,132 @@ public interface PosixAPI {
     }
 
     /**
-     * Closes a file descriptor.
+     * Close a file descriptor.
      *
-     * @param fd The file descriptor to close.
-     * @return 0 on success, -1 on error.
+     * @param fd descriptor to close
+     * @return 0 on success, -1 on error
+     * @see <a href="https://man7.org/linux/man-pages/man2/close.2.html">close(2)</a>
+     * @since 2.27
      */
     int close(int fd);
 
     /**
-     * Allocates space for a file descriptor.
+     * Preallocate space for a file.
      *
-     * @param fd     The file descriptor.
-     * @param mode   The allocation mode.
-     * @param offset The offset in the file.
-     * @param length The length of the allocation.
-     * @return 0 on success, -1 on error.
+     * @see <a href="https://man7.org/linux/man-pages/man2/fallocate.2.html">fallocate(2)</a>
+     * @param fd     descriptor
+     * @param mode   allocation mode
+     * @param offset start offset
+     * @param length bytes to allocate
+     * @return 0 on success, -1 on error
+     * @since 2.27
      */
     int fallocate(int fd, int mode, long offset, long length);
 
     /**
-     * Truncates a file descriptor to a specified length.
+     * Truncate a file to the given length.
      *
-     * @param fd     The file descriptor.
-     * @param offset The length to truncate to.
-     * @return 0 on success, -1 on error.
+     * @see <a href="https://man7.org/linux/man-pages/man2/ftruncate.2.html">ftruncate(2)</a>
+     * @param fd     descriptor
+     * @param offset new length
+     * @return 0 on success, -1 on error
+     * @since 2.27
      */
     int ftruncate(int fd, long offset);
 
     /**
-     * Repositions the read/write file offset.
+     * Move the file offset.
      *
-     * @param fd     The file descriptor.
-     * @param offset The offset to seek to.
-     * @param whence The directive for how to seek.
-     * @return The resulting offset location measured in bytes from the beginning of the file.
+     * @param fd     descriptor
+     * @param offset new offset
+     * @param whence how to interpret {@code offset}
+     * @return resulting file position
+     * @see <a href="https://man7.org/linux/man-pages/man2/lseek.2.html">lseek(2)</a>
+     * @since 2.27
      */
     default long lseek(int fd, long offset, WhenceFlag whence) {
         return lseek(fd, offset, whence.value());
     }
 
     /**
-     * Repositions the read/write file offset.
+     * Move the file offset.
      *
-     * @param fd     The file descriptor.
-     * @param offset The offset to seek to.
-     * @param whence The directive for how to seek.
-     * @return The resulting offset location measured in bytes from the beginning of the file.
+     * @param fd     descriptor
+     * @param offset new offset
+     * @param whence see {@link WhenceFlag}
+     * @return resulting file position
+     * @see <a href="https://man7.org/linux/man-pages/man2/lseek.2.html">lseek(2)</a>
+     * @since 2.27
      */
     long lseek(int fd, long offset, int whence);
 
     /**
-     * Locks a section of a file descriptor.
+     * Apply or test a byte-range lock.
      *
-     * @param fd  The file descriptor.
-     * @param cmd The command to perform.
-     * @param len The length of the section to lock.
-     * @return 0 on success, -1 on error.
+     * @param fd  descriptor
+     * @param cmd command, see {@link LockfFlag}
+     * @param len length in bytes
+     * @return 0 on success, -1 on error
+     * @see <a href="https://man7.org/linux/man-pages/man3/lockf.3.html">lockf(3)</a>
+     * @since 2.27
      */
     int lockf(int fd, int cmd, long len);
 
     /**
-     * Advises the kernel about how to handle paging input/output.
+     * Wrapper for {@link #madvise(long, long, int)} using {@link MAdviseFlag}.
+     * Thread-safe and does not allocate.
      *
-     * @param addr   The address.
-     * @param length The length.
-     * @param advice The advice directive.
-     * @return 0 on success, -1 on error.
+     * @param addr   memory address
+     * @param length length in bytes
+     * @param advice advice flag
+     * @return 0 on success, -1 on error
+     * @since 2.27
      */
     default int madvise(long addr, long length, MAdviseFlag advice) {
         return madvise(addr, length, advice.value());
     }
 
     /**
-     * Advises the kernel about how to handle paging input/output.
+     * Provide paging advice to the kernel.
      *
-     * @param addr   The address.
-     * @param length The length.
-     * @param advice The advice directive.
-     * @return 0 on success, -1 on error.
+     * @param addr   memory address
+     * @param length length in bytes
+     * @param advice advice bit mask
+     * @return 0 on success, -1 on error
+     * @see <a href="https://man7.org/linux/man-pages/man2/madvise.2.html">madvise(2)</a>
+     * @since 2.27
      */
     int madvise(long addr, long length, int advice);
 
     /**
-     * Maps files or devices into memory.
+     * Convenience overload of {@link #mmap(long, long, int, int, int, long)}.
+     * No allocation performed.
      *
-     * @param addr   The address.
-     * @param length The length.
-     * @param prot   The desired memory protection.
-     * @param flags  The flags.
-     * @param fd     The file descriptor.
-     * @param offset The offset.
-     * @return The starting address of the mapped area.
+     * @param addr   address hint
+     * @param length length in bytes
+     * @param prot   protection flags
+     * @param flags  mapping flags
+     * @param fd     file descriptor
+     * @param offset file offset
+     * @return starting address of the mapped area
+     * @since 2.27
      */
     default long mmap(long addr, long length, MMapProt prot, MMapFlag flags, int fd, long offset) {
         return mmap(addr, length, prot.value(), flags.value(), fd, offset);
     }
 
     /**
-     * Maps files or devices into memory.
+     * Map files or devices into memory.
      *
-     * @param addr   The address.
-     * @param length The length.
-     * @param prot   The desired memory protection.
-     * @param flags  The flags.
-     * @param fd     The file descriptor.
-     * @param offset The offset.
-     * @return The starting address of the mapped area.
+     * @param addr   address hint
+     * @param length length in bytes
+     * @param prot   protection bits
+     * @param flags  mapping flags
+     * @param fd     file descriptor
+     * @param offset file offset
+     * @return starting address of the mapped area
+     * @see <a href="https://man7.org/linux/man-pages/man2/mmap.2.html">mmap(2)</a>
+     * @since 2.27
      */
     long mmap(long addr, long length, int prot, int flags, int fd, long offset);
 
@@ -181,84 +206,98 @@ public interface PosixAPI {
     }
 
     /**
-     * Synchronizes changes to a file with the storage device.
+     * Convenience overload of {@link #msync(long, long, int)}.
      *
-     * @param address The address.
-     * @param length  The length.
-     * @param flags   The flags.
-     * @return 0 on success, -1 on error.
+     * @param address start address
+     * @param length  length in bytes
+     * @param flags   sync flags
+     * @return 0 on success, -1 on error
+     * @since 2.27
      */
     default int msync(long address, long length, MSyncFlag flags) {
         return msync(address, length, flags.value());
     }
 
     /**
-     * Synchronizes changes to a file with the storage device.
+     * Flush modified pages to their backing storage.
      *
-     * @param address The address.
-     * @param length  The length.
-     * @param mode    The synchronization mode.
-     * @return 0 on success, -1 on error.
+     * @param address start address
+     * @param length  length in bytes
+     * @param mode    flags bit mask
+     * @return 0 on success, -1 on error
+     * @see <a href="https://man7.org/linux/man-pages/man2/msync.2.html">msync(2)</a>
+     * @since 2.27
      */
     int msync(long address, long length, int mode);
 
     /**
-     * Unmaps files or devices from memory.
+     * Unmap a region previously mapped with {@code mmap}.
      *
-     * @param addr   The address.
-     * @param length The length.
-     * @return 0 on success, -1 on error.
+     * @param addr   start address
+     * @param length length in bytes
+     * @return 0 on success, -1 on error
+     * @see <a href="https://man7.org/linux/man-pages/man2/munmap.2.html">munmap(2)</a>
+     * @since 2.27
      */
     int munmap(long addr, long length);
 
     /**
-     * Opens a file descriptor.
+     * Overload of {@link #open(CharSequence, int, int)} using {@link OpenFlag}.
      *
-     * @param path  The path to the file.
-     * @param flags The flags.
-     * @param perm  The permissions.
-     * @return The file descriptor.
+     * @param path  file to open
+     * @param flags option flags
+     * @param perm  permissions
+     * @return file descriptor
+     * @since 2.27
      */
     default int open(CharSequence path, OpenFlag flags, int perm) {
         return open(path, flags.value(), perm);
     }
 
     /**
-     * Opens a file descriptor.
+     * Open a file.
      *
-     * @param path  The path to the file.
-     * @param flags The flags.
-     * @param perm  The permissions.
-     * @return The file descriptor.
+     * @param path  file path
+     * @param flags bit mask of {@code O_*}
+     * @param perm  permissions
+     * @return file descriptor
+     * @see <a href="https://man7.org/linux/man-pages/man2/open.2.html">open(2)</a>
+     * @since 2.27
      */
     int open(CharSequence path, int flags, int perm);
 
     /**
-     * Reads from a file descriptor.
+     * Read bytes from a file descriptor into native memory.
      *
-     * @param fd  The file descriptor.
-     * @param dst The destination address.
-     * @param len The number of bytes to read.
-     * @return The number of bytes read.
+     * @param fd  descriptor
+     * @param dst destination address
+     * @param len number of bytes
+     * @return bytes read
+     * @see <a href="https://man7.org/linux/man-pages/man2/read.2.html">read(2)</a>
+     * @since 2.27
      */
     long read(int fd, long dst, long len);
 
     /**
-     * Writes to a file descriptor.
+     * Write bytes from native memory to a file descriptor.
      *
-     * @param fd  The file descriptor.
-     * @param src The source address.
-     * @param len The number of bytes to write.
-     * @return The number of bytes written.
+     * @param fd  descriptor
+     * @param src source address
+     * @param len number of bytes
+     * @return bytes written
+     * @see <a href="https://man7.org/linux/man-pages/man2/write.2.html">write(2)</a>
+     * @since 2.27
      */
     long write(int fd, long src, long len);
 
     /**
-     * Calculates disk usage for a given filename.
+     * Invokes the {@code du} command to compute disk usage. Spawns a new process
+     * and reads its output. Thread-safe as it performs no shared mutations.
      *
-     * @param filename The filename to calculate disk usage for.
-     * @return The disk usage in bytes.
-     * @throws IOException If an I/O error occurs.
+     * @param filename path to inspect
+     * @return usage in bytes
+     * @throws IOException if the child process fails
+     * @since 2.27
      */
     default long du(String filename) throws IOException {
         ProcessBuilder pb = new ProcessBuilder("du", filename);
@@ -271,38 +310,47 @@ public interface PosixAPI {
     }
 
     /**
-     * Gets the current time of day.
+     * Fill the supplied {@code timeval} structure with the current time.
      *
-     * @param timeval The address of the timeval structure.
-     * @return 0 on success, -1 on error.
+     * @param timeval address of a two-field structure
+     * @return 0 on success, -1 on error
+     * @see <a href="https://man7.org/linux/man-pages/man2/gettimeofday.2.html">gettimeofday(2)</a>
+     * @since 2.27
      */
     int gettimeofday(long timeval);
 
     /**
-     * Sets the CPU affinity for a process.
+     * Native wrapper for {@code sched_setaffinity(2)}.
      *
-     * @param pid        The process ID.
-     * @param cpusetsize The size of the CPU set.
-     * @param mask       The CPU set mask.
-     * @return 0 on success, -1 on error.
+     * @param pid        process ID
+     * @param cpusetsize size of mask in bytes
+     * @param mask       pointer to CPU mask
+     * @return 0 on success, -1 on error
+     * @see <a href="https://man7.org/linux/man-pages/man2/sched_setaffinity.2.html">sched_setaffinity(2)</a>
+     * @since 2.27
      */
     int sched_setaffinity(int pid, int cpusetsize, long mask);
 
     /**
-     * Gets the CPU affinity for a process.
+     * Retrieve CPU affinity mask.
      *
-     * @param pid        The process ID.
-     * @param cpusetsize The size of the CPU set.
-     * @param mask       The CPU set mask.
-     * @return 0 on success, -1 on error.
+     * @param pid        process ID
+     * @param cpusetsize size of mask in bytes
+     * @param mask       pointer to CPU mask
+     * @return 0 on success, -1 on error
+     * @see <a href="https://man7.org/linux/man-pages/man2/sched_getaffinity.2.html">sched_getaffinity(2)</a>
+     * @since 2.27
      */
     int sched_getaffinity(int pid, int cpusetsize, long mask);
 
     /**
-     * Returns a summary of the CPU affinity for a given process ID.
+     * Reports the CPU affinity mask for the given process as a compressed string
+     * (for example "0-3,8"). The mask is built using {@link #malloc(long)} and
+     * freed with {@link #free(long)}. This method is thread-safe.
      *
-     * @param pid The process ID.
-     * @return A summary of the CPU affinity as a string.
+     * @param pid process ID
+     * @return comma separated range specification, or "na: <errno>" on failure
+     * @since 2.27
      */
     default String sched_getaffinity_summary(int pid) {
         final int nprocs_conf = get_nprocs_conf();
@@ -345,18 +393,22 @@ public interface PosixAPI {
     }
 
     /**
-     * Returns the last error code.
+     * Retrieve the last native error number.
      *
-     * @return The last error code.
+     * @return errno value
+     * @since 2.27
      */
     int lastError();
 
     /**
-     * Sets the CPU affinity for a process to a specific CPU.
+     * Pins the process to a single CPU. The method allocates a small mask via
+     * {@link #malloc(long)} and releases it with {@link #free(long)}. It is
+     * safe for concurrent use.
      *
-     * @param pid The process ID.
-     * @param cpu The CPU to set affinity to.
-     * @return 0 on success, -1 on error.
+     * @param pid process ID
+     * @param cpu zero-based CPU index
+     * @return 0 on success, -1 on error
+     * @since 2.27
      */
     default int sched_setaffinity_as(int pid, int cpu) {
         final int nprocs_conf = get_nprocs_conf();
@@ -375,12 +427,15 @@ public interface PosixAPI {
     }
 
     /**
-     * Sets the CPU affinity for a process to a range of CPUs.
+     * Binds the process to a contiguous range of CPUs. Uses {@link #malloc(long)}
+     * to build the mask and {@link #free(long)} to release it. The method is
+     * thread-safe and may be called concurrently.
      *
-     * @param pid  The process ID.
-     * @param from The starting CPU.
-     * @param to   The ending CPU.
-     * @return 0 on success, -1 on error.
+     * @param pid  target process ID
+     * @param from first CPU in the range
+     * @param to   last CPU in the range
+     * @return 0 on success, -1 on error
+     * @since 2.27
      */
     default int sched_setaffinity_range(int pid, int from, int to) {
         final int nprocs_conf = get_nprocs_conf();
@@ -401,10 +456,12 @@ public interface PosixAPI {
     }
 
     /**
-     * Returns the current wall clock time in microseconds.
-     * Note that clock_gettime() is more accurate if available.
+     * Helper using {@link #malloc(long)} to call {@link #gettimeofday(long)} and
+     * convert the result to microseconds. Memory is released with
+     * {@link #free(long)}. Safe for concurrent use.
      *
-     * @return The wall clock time in microseconds.
+     * @return wall clock time in microseconds or {@code 0} on error
+     * @since 2.27
      */
     default long gettimeofday() {
         long ptr = malloc(16);
@@ -420,89 +477,101 @@ public interface PosixAPI {
     }
 
     /**
-     * Returns the current wall clock time in nanoseconds.
+     * Current wall clock time in nanoseconds using {@code CLOCK_REALTIME}.
      *
-     * @return The wall clock time in nanoseconds.
+     * @return wall clock time
+     * @since 2.27
      */
     default long clock_gettime() {
         return clock_gettime(0 /* CLOCK_REALTIME */);
     }
 
     /**
-     * Returns the current wall clock time for a specific clock ID in nanoseconds.
+     * Return the wall clock time for a given clock.
      *
-     * @param clockId The clock ID.
-     * @return The wall clock time in nanoseconds.
-     * @throws IllegalArgumentException If the clock ID is invalid.
+     * @param clockId the clock ID
+     * @return wall clock time
+     * @throws IllegalArgumentException if the clock ID is invalid
+     * @since 2.27
      */
     default long clock_gettime(ClockId clockId) throws IllegalArgumentException {
         return clock_gettime(clockId.value());
     }
 
     /**
-     * Returns the current wall clock time for a specific clock ID in nanoseconds.
+     * Native wrapper for {@code clock_gettime(2)}.
      *
-     * @param clockId The clock ID.
-     * @return The wall clock time in nanoseconds.
-     * @throws IllegalArgumentException If the clock ID is invalid.
+     * @param clockId the clock ID
+     * @return wall clock time
+     * @throws IllegalArgumentException if the clock ID is invalid
+     * @see <a href="https://man7.org/linux/man-pages/man2/clock_gettime.2.html">clock_gettime(2)</a>
+     * @since 2.27
      */
     long clock_gettime(int clockId) throws IllegalArgumentException;
 
     /**
-     * Allocates memory of a specified size.
+     * Allocate native memory.
      *
-     * @param size The size of the memory to allocate.
-     * @return The address of the allocated memory.
+     * @param size number of bytes
+     * @return address of allocated memory
+     * @since 2.27
      */
     long malloc(long size);
 
     /**
-     * Frees allocated memory.
+     * Release memory previously allocated with {@link #malloc(long)}.
      *
-     * @param ptr The address of the memory to free.
+     * @param ptr address to free
+     * @since 2.27
      */
     void free(long ptr);
 
     /**
-     * Returns the number of available processors.
+     * Number of available processors.
      *
-     * @return The number of available processors.
+     * @return processor count
+     * @since 2.27
      */
     int get_nprocs();
 
     /**
-     * Returns the number of configured processors.
+     * Number of configured processors.
      *
-     * @return The number of configured processors.
+     * @return processor count
+     * @since 2.27
      */
     int get_nprocs_conf();
 
     /**
-     * Returns the process ID.
+     * Process ID of the calling process.
      *
-     * @return The process ID.
+     * @return pid
+     * @since 2.27
      */
     int getpid();
 
     /**
-     * Returns the thread ID.
+     * Thread ID of the caller.
      *
-     * @return The thread ID.
+     * @return tid
+     * @since 2.27
      */
     int gettid();
 
     /**
-     * Returns the error message for a given error code.
+     * Convert an errno value to a message.
      *
-     * @param errno The error code.
-     * @return The error message.
+     * @param errno error number
+     * @return message string
+     * @since 2.27
      */
     String strerror(int errno);
 
     /**
-     * Returns the last error message.
+     * Human readable form of {@link #lastError()}.
      *
-     * @return The last error message.
+     * @return error message
+     * @since 2.27
      */
     default String lastErrorStr() {
         return strerror(lastError());

--- a/src/main/java/net/openhft/posix/ProcMaps.java
+++ b/src/main/java/net/openhft/posix/ProcMaps.java
@@ -11,18 +11,20 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.toList;
 
 /**
- * This class provides methods to read and parse the memory mappings from the /proc filesystem on Linux.
- * It allows users to retrieve memory mappings for the current process or a specified process ID (PID).
+ * Reader for {@code /proc/[pid]/maps}.
+ *
+ * @see <a href="https://man7.org/linux/man-pages/man5/proc.5.html">proc(5)</a>
+ * @since 2.27
  */
 public final class ProcMaps {
     // A list to hold the memory mappings
     private final List<Mapping> mappingList = new ArrayList<>();
 
     /**
-     * Private constructor to initialize ProcMaps with mappings from the specified process.
+     * Reads mappings for the given process.
      *
-     * @param proc The process identifier (could be "self" for the current process).
-     * @throws IOException If an I/O error occurs reading from the /proc filesystem.
+     * @param proc process id or "self"
+     * @throws IOException on read failure
      */
     private ProcMaps(Object proc) throws IOException {
         try (BufferedReader br = new BufferedReader(new FileReader("/proc/" + proc + "/maps"))) {
@@ -33,40 +35,39 @@ public final class ProcMaps {
     }
 
     /**
-     * Factory method to create a ProcMaps instance for the current process.
+     * Create a {@link ProcMaps} for the current process.
      *
-     * @return A ProcMaps instance for the current process.
-     * @throws IOException If an I/O error occurs reading from the /proc filesystem.
+     * @return mappings for this process
+     * @throws IOException on read failure
+     * @since 2.27
      */
     public static ProcMaps forSelf() throws IOException {
         return new ProcMaps("self");
     }
 
     /**
-     * Factory method to create a ProcMaps instance for a specified process ID (PID).
+     * Create a {@link ProcMaps} for the given PID.
      *
-     * @param pid The process ID to read memory mappings for.
-     * @return A ProcMaps instance for the specified PID.
-     * @throws IOException If an I/O error occurs reading from the /proc filesystem.
+     * @param pid target process id
+     * @return mappings for the process
+     * @throws IOException on read failure
+     * @since 2.27
      */
     public static ProcMaps forPID(int pid) throws IOException {
         return new ProcMaps(pid);
     }
 
-    /**
-     * Returns an unmodifiable list of memory mappings.
-     *
-     * @return An unmodifiable list of memory mappings.
-     */
+    /** Immutable list of mappings. */
     public List<Mapping> list() {
         return unmodifiableList(mappingList);
     }
 
     /**
-     * Finds the first memory mapping that matches the given predicate.
+     * First mapping matching the predicate.
      *
-     * @param test The predicate to test memory mappings.
-     * @return The first matching memory mapping.
+     * @param test filter condition
+     * @return the first match
+     * @since 2.27
      */
     public Mapping findFirst(Predicate<? super Mapping> test) {
         return mappingList.stream()
@@ -76,10 +77,11 @@ public final class ProcMaps {
     }
 
     /**
-     * Finds all memory mappings that match the given predicate.
+     * All mappings matching the predicate.
      *
-     * @param test The predicate to test memory mappings.
-     * @return A list of all matching memory mappings.
+     * @param test filter condition
+     * @return list of matches
+     * @since 2.27
      */
     public List<Mapping> findAll(Predicate<? super Mapping> test) {
         return mappingList.stream()

--- a/src/main/java/net/openhft/posix/WhenceFlag.java
+++ b/src/main/java/net/openhft/posix/WhenceFlag.java
@@ -1,55 +1,42 @@
 package net.openhft.posix;
 
 /**
- * This enum represents the different flags for seeking within a file (whence).
- * It defines the options used to set the file offset for read/write operations.
+ * Constants for the {@code lseek(2)} {@code whence} argument.
+ *
+ * @see <a href="https://man7.org/linux/man-pages/man2/lseek.2.html">lseek(2)</a>
+ * @since 2.27
  */
 public enum WhenceFlag {
-    /**
-     * The offset is set to offset bytes.
-     */
+    /** Offset is set to {@code offset} bytes. */
     SEEK_SET(1),
 
-    /**
-     * The offset is set to its current location plus offset bytes.
-     */
+    /** Add {@code offset} to the current location. */
     SEEK_CUR(2),
 
-    /**
-     * The offset is set to the size of the file plus offset bytes.
-     */
+    /** Set offset relative to end of file. */
     SEEK_END(3),
 
-    /**
-     * Adjust the file offset to the next location in the file greater than or equal to offset containing data.
-     * If offset points to data, then the file offset is set to offset.
-     */
+    /** Move to the next data region at or after {@code offset}. */
     SEEK_DATA(4),
 
-    /**
-     * Adjust the file offset to the next hole in the file greater than or equal to offset.
-     * If offset points into the middle of a hole, then the file offset is set to offset.
-     * If there is no hole past offset, then the file offset is adjusted to the end of the file (i.e., there is an implicit hole at the end of any file).
-     */
+    /** Move to the next hole at or after {@code offset}. */
     SEEK_HOLE(5);
 
     // The integer value representing the whence flag
     private final int value;
 
     /**
-     * Constructor for WhenceFlag.
-     *
-     * @param value The integer value representing the whence flag
+     * @param value native constant value
      */
     WhenceFlag(int value) {
         this.value = value;
     }
 
     /**
-     * This method is a getter for the value instance variable.
-     * It returns the current integer value of this WhenceFlag object.
+     * Native constant value.
      *
-     * @return The current integer value of this WhenceFlag object
+     * @return integer to pass to {@code lseek}
+     * @since 2.27
      */
     public int value() {
         return value;


### PR DESCRIPTION
## Summary
- remove outdated duplicated Javadoc for `fallocate` and `ftruncate`
- keep concise behavioural notes on default methods

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*