### PR TITLE
Document exceptions in Mapping constructor

### DIFF
--- a/src/main/java/net/openhft/posix/Mapping.java
+++ b/src/main/java/net/openhft/posix/Mapping.java
@@ -43,6 +43,9 @@ public final class Mapping {
      * Parses a mapping line from {@code /proc/[pid]/maps}.
      *
      * @param line textual line from the maps file
+     * @throws NumberFormatException        if address or inode fields are not
+     *                                      valid hex or decimal numbers
+     * @throws ArrayIndexOutOfBoundsException if fields are missing
      */
     public Mapping(String line) {
         String[] parts = line.split(" +");


### PR DESCRIPTION
## Summary
- clarify Mapping constructor's exceptions

## Testing
- `mvn -q verify` *(fails: mvn not found)*