### PR TITLE
Clarify enum docs for system call flags

### DIFF
--- a/src/main/java/net/openhft/posix/ClockId.java
+++ b/src/main/java/net/openhft/posix/ClockId.java
@@ -1,11 +1,10 @@
 package net.openhft.posix;
 
 /**
- * Identifiers for {@code clock_gettime(2)}.
+ * Identifiers for the {@code clock_gettime(2)} system call.
  *
- * Clock IDs for operations like {@code clock_gettime}.
+ * <p>The integer values mirror the glibc headers for binary compatibility.</p>
  *
- * <p>The integer values are binary-compatible with the glibc headers.
  * @see <a href="https://man7.org/linux/man-pages/man2/clock_gettime.2.html">clock_gettime(2)</a>
  */
 public enum ClockId {
@@ -54,9 +53,9 @@ public enum ClockId {
     }
 
     /**
-     * Constant to pass to {@code clock_gettime}.
+     * Returns the native integer to pass to {@code clock_gettime}.
      *
-     * @return integer value
+     * @return native integer constant
      */
     public int value() {
         return value;

--- a/src/main/java/net/openhft/posix/LockfFlag.java
+++ b/src/main/java/net/openhft/posix/LockfFlag.java
@@ -1,9 +1,10 @@
 package net.openhft.posix;
 
 /**
- * Operations for {@code lockf(3)}.
+ * Operations for the {@code lockf(3)} library call.
  *
- * <p>The integer values are binary-compatible with the glibc headers.
+ * <p>The integer values mirror the glibc headers for binary compatibility.</p>
+ *
  * @see <a href="https://man7.org/linux/man-pages/man3/lockf.3.html">lockf(3)</a>
  */
 public enum LockfFlag {
@@ -30,9 +31,9 @@ public enum LockfFlag {
     }
 
     /**
-     * Constant to pass to {@code lockf}.
+     * Returns the native integer to pass to {@code lockf}.
      *
-     * @return integer value
+     * @return native integer constant
      */
     public int value() {
         return value;

--- a/src/main/java/net/openhft/posix/MAdviseFlag.java
+++ b/src/main/java/net/openhft/posix/MAdviseFlag.java
@@ -1,9 +1,10 @@
 package net.openhft.posix;
 
 /**
- * Advice flags for {@code madvise(2)}.
+ * Advice flags for the {@code madvise(2)} system call.
  *
- * <p>The integer values are binary-compatible with the glibc headers.
+ * <p>The integer values mirror the glibc headers for binary compatibility.</p>
+ *
  * @see <a href="https://man7.org/linux/man-pages/man2/madvise.2.html">madvise(2)</a>
  */
 public enum MAdviseFlag {
@@ -69,9 +70,9 @@ public enum MAdviseFlag {
     }
 
     /**
-     * Constant to pass to {@code madvise}.
+     * Returns the native integer to pass to {@code madvise}.
      *
-     * @return integer value
+     * @return native integer constant
      */
     public int value() {
         return value;

--- a/src/main/java/net/openhft/posix/MMapFlag.java
+++ b/src/main/java/net/openhft/posix/MMapFlag.java
@@ -1,9 +1,10 @@
 package net.openhft.posix;
 
 /**
- * Mapping flags for {@code mmap(2)}.
+ * Mapping flags for the {@code mmap(2)} system call.
  *
- * <p>The integer values are binary-compatible with the glibc headers.
+ * <p>The integer values mirror the glibc headers for binary compatibility.</p>
+ *
  * @see <a href="https://man7.org/linux/man-pages/man2/mmap.2.html">mmap(2)</a>
  */
 public enum MMapFlag {
@@ -24,9 +25,9 @@ public enum MMapFlag {
     }
 
     /**
-     * Constant to pass to {@code mmap}.
+     * Returns the native integer to pass to {@code mmap}.
      *
-     * @return integer value
+     * @return native integer constant
      */
     public int value() {
         return value;

--- a/src/main/java/net/openhft/posix/MMapProt.java
+++ b/src/main/java/net/openhft/posix/MMapProt.java
@@ -1,9 +1,10 @@
 package net.openhft.posix;
 
 /**
- * Protection flags for {@code mmap(2)}.
+ * Protection flags for the {@code mmap(2)} system call.
  *
- * <p>The integer values are binary-compatible with the glibc headers.
+ * <p>The integer values mirror the glibc headers for binary compatibility.</p>
+ *
  * @see <a href="https://man7.org/linux/man-pages/man2/mmap.2.html">mmap(2)</a>
  */
 public enum MMapProt {
@@ -36,9 +37,9 @@ public enum MMapProt {
     }
 
     /**
-     * Constant to pass to {@code mmap}.
+     * Returns the native integer to pass to {@code mmap}.
      *
-     * @return integer value
+     * @return native integer constant
      */
     public int value() {
         return value;

--- a/src/main/java/net/openhft/posix/MSyncFlag.java
+++ b/src/main/java/net/openhft/posix/MSyncFlag.java
@@ -1,9 +1,10 @@
 package net.openhft.posix;
 
 /**
- * Flags for {@code msync(2)}.
+ * Flags for the {@code msync(2)} system call.
  *
- * <p>The integer values are binary-compatible with the glibc headers.
+ * <p>The integer values mirror the glibc headers for binary compatibility.</p>
+ *
  * @see <a href="https://man7.org/linux/man-pages/man2/msync.2.html">msync(2)</a>
  */
 public enum MSyncFlag {
@@ -27,9 +28,9 @@ public enum MSyncFlag {
     }
 
     /**
-     * Constant to pass to {@code msync}.
+     * Returns the native integer to pass to {@code msync}.
      *
-     * @return integer value
+     * @return native integer constant
      */
     public int value() {
         return value;

--- a/src/main/java/net/openhft/posix/MclFlag.java
+++ b/src/main/java/net/openhft/posix/MclFlag.java
@@ -1,9 +1,10 @@
 package net.openhft.posix;
 
 /**
- * Flags for {@code mlockall(2)}.
+ * Flags for the {@code mlockall(2)} system call.
  *
- * <p>The integer values are binary-compatible with the glibc headers.
+ * <p>The integer values mirror the glibc headers for binary compatibility.</p>
+ *
  * @see <a href="https://man7.org/linux/man-pages/man2/mlockall.2.html">mlockall(2)</a>
  */
 public enum MclFlag {
@@ -30,9 +31,9 @@ public enum MclFlag {
     }
 
     /**
-     * Constant to pass to {@code mlockall}.
+     * Returns the native integer to pass to {@code mlockall}.
      *
-     * @return integer value
+     * @return native integer constant
      */
     public int code() {
         return code;

--- a/src/main/java/net/openhft/posix/OpenFlag.java
+++ b/src/main/java/net/openhft/posix/OpenFlag.java
@@ -1,7 +1,9 @@
 package net.openhft.posix;
 
 /**
- * Flags for {@code open(2)}.
+ * Flags for the {@code open(2)} system call.
+ *
+ * <p>The integer values mirror the glibc headers for binary compatibility.</p>
  *
  * @see <a href="https://man7.org/linux/man-pages/man2/open.2.html">open(2)</a>
  */
@@ -53,9 +55,9 @@ public enum OpenFlag {
     }
 
     /**
-     * Constant to pass to {@code open}.
+     * Returns the native integer to pass to {@code open}.
      *
-     * @return integer value
+     * @return native integer constant
      */
     public int value() {
         return value;

--- a/src/main/java/net/openhft/posix/WhenceFlag.java
+++ b/src/main/java/net/openhft/posix/WhenceFlag.java
@@ -3,6 +3,8 @@ package net.openhft.posix;
 /**
  * Constants for the {@code lseek(2)} {@code whence} argument.
  *
+ * <p>The integer values mirror the glibc headers for binary compatibility.</p>
+ *
  * @see <a href="https://man7.org/linux/man-pages/man2/lseek.2.html">lseek(2)</a>
  */
 public enum WhenceFlag {
@@ -32,9 +34,9 @@ public enum WhenceFlag {
     }
 
     /**
-     * Native constant value.
+     * Returns the native integer to pass to {@code lseek}.
      *
-     * @return integer to pass to {@code lseek}
+     * @return native integer constant
      */
     public int value() {
         return value;


### PR DESCRIPTION
## Summary
- update Javadoc for system-call flag enums
- describe glibc compatibility
- document that each `value()` or `code()` returns the native integer

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*