### PR TITLE
Clarify Jvm and OS utility classes

### DIFF
--- a/src/main/java/net/openhft/posix/internal/core/Jvm.java
+++ b/src/main/java/net/openhft/posix/internal/core/Jvm.java
@@ -3,12 +3,12 @@ package net.openhft.posix.internal.core;
 import net.openhft.posix.internal.UnsafeMemory;
 
 /**
- * Utility class to access information about the JVM. Values are captured at
- * class initialisation and never updated.
+ * Exposes static information about the running JVM.
+ * Values are captured when the class loads and never updated.
  */
 public final class Jvm {
 
-    // Suppresses default constructor, ensuring non-instantiability
+    /** Private constructor to prevent instantiation. */
     private Jvm() {
     }
 
@@ -25,9 +25,9 @@ public final class Jvm {
     static final String VM_VENDOR = System.getProperty("java.vm.vendor", "?");
 
     /**
-     * Checks if the JVM is running on an ARM architecture. Thread-safe.
+     * Detects if the JVM runs on an ARM CPU.
      *
-     * @return true if the JVM is running on an ARM architecture, false otherwise.
+     * @return true when the JVM is hosted on ARM
      */
     public static boolean isArm() {
         return Boolean.parseBoolean(System.getProperty("jvm.isarm")) ||
@@ -35,18 +35,18 @@ public final class Jvm {
     }
 
     /**
-     * Checks if the JVM is 64-bit. Thread-safe.
+     * Determines if the JVM is 64-bit.
      *
-     * @return true if the JVM is 64-bit, false otherwise.
+     * @return true for a 64-bit JVM
      */
     public static boolean is64bit() {
         return UnsafeMemory.IS64BIT;
     }
 
     /**
-     * Checks if the JVM is provided by Azul Systems. Thread-safe.
+     * Determines if the JVM vendor is Azul Systems.
      *
-     * @return true if the JVM vendor is Azul Systems, false otherwise.
+     * @return true when running on Azul Systems
      */
     public static boolean isAzul() {
         return VM_VENDOR.startsWith("Azul ");

--- a/src/main/java/net/openhft/posix/internal/core/OS.java
+++ b/src/main/java/net/openhft/posix/internal/core/OS.java
@@ -3,8 +3,8 @@ package net.openhft.posix.internal.core;
 import static net.openhft.posix.internal.core.Jvm.OS_ARCH;
 
 /**
- * Utility class to access information about the operating system. Values are
- * captured at class initialisation and never updated.
+ * Exposes static details about the host operating system.
+ * Values are captured when the class loads and never updated.
  */
 public final class OS {
 
@@ -14,14 +14,14 @@ public final class OS {
      */
     public static final String OS_NAME = System.getProperty("os.name", "?");
 
-    // Suppresses default constructor, ensuring non-instantiability
+    /** Private constructor to prevent instantiation. */
     private OS() {
     }
 
     /**
-     * Checks if the operating system is macOS. Thread-safe.
+     * Determines if the OS is macOS.
      *
-     * @return true if the operating system is macOS, false otherwise.
+     * @return true when running on macOS
      */
     public static boolean isMacOSX() {
         return OS_NAME.equals("Mac OS X");


### PR DESCRIPTION
## Summary
- document the JVM and OS helpers as non-instantiable utility classes
- tighten Javadoc on detection helpers

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*