### PR TITLE
docs: bump copyright year end from 2025 to 2026

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <!--
 
-    Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+    Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <packaging>jar</packaging>
 
     <properties>
+        <license.year>2013-2026</license.year>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jacoco.line.coverage>0.6</jacoco.line.coverage>
         <jacoco.branch.coverage>0.4</jacoco.branch.coverage>

--- a/src/main/java/net/openhft/posix/ClockId.java
+++ b/src/main/java/net/openhft/posix/ClockId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix;
 

--- a/src/main/java/net/openhft/posix/LockfFlag.java
+++ b/src/main/java/net/openhft/posix/LockfFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix;
 

--- a/src/main/java/net/openhft/posix/MAdviseFlag.java
+++ b/src/main/java/net/openhft/posix/MAdviseFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix;
 

--- a/src/main/java/net/openhft/posix/MMapFlag.java
+++ b/src/main/java/net/openhft/posix/MMapFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix;
 

--- a/src/main/java/net/openhft/posix/MMapProt.java
+++ b/src/main/java/net/openhft/posix/MMapProt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix;
 

--- a/src/main/java/net/openhft/posix/MSyncFlag.java
+++ b/src/main/java/net/openhft/posix/MSyncFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix;
 

--- a/src/main/java/net/openhft/posix/Mapping.java
+++ b/src/main/java/net/openhft/posix/Mapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix;
 

--- a/src/main/java/net/openhft/posix/MclFlag.java
+++ b/src/main/java/net/openhft/posix/MclFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix;
 

--- a/src/main/java/net/openhft/posix/OpenFlag.java
+++ b/src/main/java/net/openhft/posix/OpenFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix;
 

--- a/src/main/java/net/openhft/posix/PosixAPI.java
+++ b/src/main/java/net/openhft/posix/PosixAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix;
 

--- a/src/main/java/net/openhft/posix/PosixRuntimeException.java
+++ b/src/main/java/net/openhft/posix/PosixRuntimeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix;
 

--- a/src/main/java/net/openhft/posix/ProcMaps.java
+++ b/src/main/java/net/openhft/posix/ProcMaps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix;
 

--- a/src/main/java/net/openhft/posix/WhenceFlag.java
+++ b/src/main/java/net/openhft/posix/WhenceFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix;
 

--- a/src/main/java/net/openhft/posix/internal/PosixAPIHolder.java
+++ b/src/main/java/net/openhft/posix/internal/PosixAPIHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix.internal;
 

--- a/src/main/java/net/openhft/posix/internal/UnsafeMemory.java
+++ b/src/main/java/net/openhft/posix/internal/UnsafeMemory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix.internal;
 

--- a/src/main/java/net/openhft/posix/internal/core/Jvm.java
+++ b/src/main/java/net/openhft/posix/internal/core/Jvm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix.internal.core;
 

--- a/src/main/java/net/openhft/posix/internal/core/OS.java
+++ b/src/main/java/net/openhft/posix/internal/core/OS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix.internal.core;
 

--- a/src/main/java/net/openhft/posix/internal/core/package-info.java
+++ b/src/main/java/net/openhft/posix/internal/core/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Supports operating system and JVM utilities used by the Posix API.

--- a/src/main/java/net/openhft/posix/internal/jna/JNAPosixAPI.java
+++ b/src/main/java/net/openhft/posix/internal/jna/JNAPosixAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix.internal.jna;
 

--- a/src/main/java/net/openhft/posix/internal/jna/JNAPosixInterface.java
+++ b/src/main/java/net/openhft/posix/internal/jna/JNAPosixInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix.internal.jna;
 

--- a/src/main/java/net/openhft/posix/internal/jna/package-info.java
+++ b/src/main/java/net/openhft/posix/internal/jna/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Supplies the JNA based provider of {@link net.openhft.posix.PosixAPI}.

--- a/src/main/java/net/openhft/posix/internal/jnr/JNRPosixAPI.java
+++ b/src/main/java/net/openhft/posix/internal/jnr/JNRPosixAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix.internal.jnr;
 

--- a/src/main/java/net/openhft/posix/internal/jnr/JNRPosixInterface.java
+++ b/src/main/java/net/openhft/posix/internal/jnr/JNRPosixInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix.internal.jnr;
 

--- a/src/main/java/net/openhft/posix/internal/jnr/Kernel32JNRInterface.java
+++ b/src/main/java/net/openhft/posix/internal/jnr/Kernel32JNRInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix.internal.jnr;
 

--- a/src/main/java/net/openhft/posix/internal/jnr/LibraryUtil.java
+++ b/src/main/java/net/openhft/posix/internal/jnr/LibraryUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix.internal.jnr;
 

--- a/src/main/java/net/openhft/posix/internal/jnr/WinJNRPosixAPI.java
+++ b/src/main/java/net/openhft/posix/internal/jnr/WinJNRPosixAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix.internal.jnr;
 

--- a/src/main/java/net/openhft/posix/internal/jnr/WinJNRPosixInterface.java
+++ b/src/main/java/net/openhft/posix/internal/jnr/WinJNRPosixInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix.internal.jnr;
 

--- a/src/main/java/net/openhft/posix/internal/jnr/package-info.java
+++ b/src/main/java/net/openhft/posix/internal/jnr/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Supplies the JNR based provider of {@link net.openhft.posix.PosixAPI}.

--- a/src/main/java/net/openhft/posix/internal/noop/NoOpPosixAPI.java
+++ b/src/main/java/net/openhft/posix/internal/noop/NoOpPosixAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix.internal.noop;
 

--- a/src/main/java/net/openhft/posix/internal/noop/package-info.java
+++ b/src/main/java/net/openhft/posix/internal/noop/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Contains a no-op Posix API for unsupported platforms.

--- a/src/main/java/net/openhft/posix/internal/package-info.java
+++ b/src/main/java/net/openhft/posix/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.

--- a/src/main/java/net/openhft/posix/internal/raw/RawPosixAPI.java
+++ b/src/main/java/net/openhft/posix/internal/raw/RawPosixAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix.internal.raw;
 

--- a/src/main/java/net/openhft/posix/internal/raw/package-info.java
+++ b/src/main/java/net/openhft/posix/internal/raw/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Supplies a reflection based Posix API using raw JVM access.

--- a/src/main/java/net/openhft/posix/package-info.java
+++ b/src/main/java/net/openhft/posix/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Portable subset of POSIX operations.

--- a/src/test/java/net/openhft/posix/internal/jnr/BenchmarkMain.java
+++ b/src/test/java/net/openhft/posix/internal/jnr/BenchmarkMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix.internal.jnr;
 

--- a/src/test/java/net/openhft/posix/internal/jnr/JNRPosixAPITest.java
+++ b/src/test/java/net/openhft/posix/internal/jnr/JNRPosixAPITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix.internal.jnr;
 

--- a/src/test/java/net/openhft/posix/internal/jnr/MSyncFileBenchmarkMain.java
+++ b/src/test/java/net/openhft/posix/internal/jnr/MSyncFileBenchmarkMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix.internal.jnr;
 

--- a/src/test/java/net/openhft/posix/util/Histogram.java
+++ b/src/test/java/net/openhft/posix/util/Histogram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.posix.util;
 


### PR DESCRIPTION
## Summary
- Rolls `Copyright YYYY-20XX chronicle.software` / `higherfrequencytrading.com` forward so the end year matches the current calendar year (2026).
- Non-chronicle copyrights (third-party headers, etc.) are intentionally left alone.
- Adds a local `license.year=2013-2026` override in the project POM so `license-maven-plugin` validates the updated headers correctly on CI.
- Behaviour-neutral; no logic changes.

## Test plan
- [ ] Visual diff review - expect header year updates plus the `license.year` POM override.
- [ ] `mvn -DskipTests license:check`
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)