### PR TITLE
docs: upgrade http:// to https:// in docs and comments

### DIFF
--- a/LICENSE.adoc
+++ b/LICENSE.adoc
@@ -3,7 +3,7 @@
 Licensed under the *Apache License, Version 2.0* (the "License"); you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and limitations under the License.


### PR DESCRIPTION
## Summary
- Upgrades `http://` to `https://` in documentation files (.adoc, .md, LICENSE, NOTICE, AGENTS) and Java comment lines.
- Skips XML namespace identifiers (`xmlns=`, `xsi:schemaLocation=`) and non-comment Java source where a URL might be a literal value.
- Mechanical change, no code behaviour affected.

## Test plan
- [ ] Visual diff - only protocol `http` -> `https` changes.
- [ ] Spot-check a few upgraded links still resolve.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)